### PR TITLE
Allow changing hosts from command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Load testing scripts and tooling for the Login.gov, currently using [`locust`](h
 
 ### Python and Locust
 
-Instally python3 and dependencies
+Install python3 and dependencies
 
 ```sh
 brew install python
@@ -26,6 +26,8 @@ telephony_disabled: 'true'
 ## Running Locust
 
 ```sh
-locust --host localhost:3000 --clients 1 --hatch-rate 1 --locustfile load_testing/locustfile.py
+locust --host http://localhost:3000 --clients=1 --hatch-rate 1 --locustfile load_testing/locustfile.py
 open http://localhost:8089
 ```
+
+Or add `--no-web` for a console-only experience

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -8,8 +8,6 @@ from random import randint
 """ Globals """
 fake = Factory.create()
 phone_numbers = foney.phone_numbers()
-usagov_url = "https://www.cdc.gov"
-login_url = "http://localhost:3000"
 default_password = "salty pickles"
 
 """ Helper functions """
@@ -46,38 +44,31 @@ class CovidReliefLoad(TaskSet):
     """ Things inside task are synchronous. Tasks are async """
     @task(1)
     def full_synchronous_path(self):
-        """
-        USA.gov : just make one request
-        """
-        self.client.get(usagov_url + "/coronavirus/2019-ncov/about/index.html", name="USA.gov/covid19")
-
-        """
-        Login.gov : Create new user, set up SMS, log out
-        """
-        self.client.get(login_url + "/")
+        # GET the root
+        self.client.get("/")
 
         # GET the new email page
-        resp = self.client.get(login_url + "/sign_up/enter_email", name="Login/sign_up/enter_email")
+        resp = self.client.get("/sign_up/enter_email")
         dom = resp_to_dom(resp)
 
         # Post fake email and get confirmation link (link shows up in "load test mode")
         new_email = "test+{}@test.com".format(fake.md5())
-        resp = self.client.post(login_url + "/sign_up/enter_email",
+        resp = self.client.post("/sign_up/enter_email",
                   data={
                     'user[email]': new_email,
                     'authenticity_token': authenticity_token(dom),
                   },
-                  catch_response=True, name="Login/sign_up/enter_email")
+                  catch_response=True)
         dom = resp_to_dom(resp)
         confirmation_link = dom.find("#confirm-now")[0].attrib['href']
         
         # Get confirmation token
-        resp = self.client.get(confirmation_link, name="Login/sign_up/email/confirm")
+        resp = self.client.get(confirmation_link, name="/sign_up/email/confirm?confirmation_token=")
         dom = resp_to_dom(resp)
         token = dom.find('[name="confirmation_token"]:first').attr('value')
 
         # Set user password
-        resp = self.client.post(login_url + "/sign_up/create_password",
+        resp = self.client.post("/sign_up/create_password",
                   data={
                       'password_form[password]': default_password,
                       'authenticity_token': authenticity_token(dom),
@@ -86,7 +77,7 @@ class CovidReliefLoad(TaskSet):
               )
 
         # After password creation set up SMS 2nd factor
-        phone_setup_url = login_url + "/phone_setup"
+        phone_setup_url = "/phone_setup"
         resp = self.client.get(phone_setup_url)
         dom = resp_to_dom(resp)
         auth_token = authenticity_token(dom)
@@ -108,7 +99,7 @@ class CovidReliefLoad(TaskSet):
 
         # Visit security code page and submit pre-filled OTP
         resp = self.client.post(
-            login_url + "/login/two_factor/sms",
+            "/login/two_factor/sms",
             data={
                 'code': otp_code,
                 'authenticity_token': authenticity_token(dom),


### PR DESCRIPTION
- Don't use full urls with locust so that the `--host` setting works.
- Remove test against non-IDP endpoint, we'll do that with different locustfiles
- Add some simple error handling around often mis-configured IDP options