### PR TITLE
Cleaner errors from Locust

### DIFF
--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -1,10 +1,13 @@
+import locust
 import pyquery
 from random import randint
 
 # Utility functions that are helpful in various locust contexts
 
 
-def do_request(context, method, path, expected_redirect=None, data={}, files={}, name=None):
+def do_request(
+    context, method, path, expected_redirect=None, data={}, files={}, name=None
+):
     with getattr(context.client, method)(
         path,
         headers=desktop_agent_headers(),
@@ -28,7 +31,9 @@ def authenticity_token(response, index=0):
 
     dom = resp_to_dom(response)
     token = dom.find(selector).eq(index).attr("value")
-    # print("Returning authenticity_token: {}".format(token))
+    if not token:
+        response.failure("Could not find authenticity_token on page")
+        raise locust.exception.RescheduleTask
 
     return token
 
@@ -37,11 +42,16 @@ def otp_code(response):
     """
     Retrieves the auto-populated OTP code from the DOM for submission.
     """
-    selector = 'input[name="code"]'
-
     dom = resp_to_dom(response)
+    selector = 'input[name="code"]'
+    error_message = (
+        "Could not find pre-filled OTP code, is IDP telephony_adapter: 'test' ?"
+    )
+
     code = dom.find(selector).attr("value")
-    # print("Returning OTP code: {}".format(code))
+    if not code:
+        response.failure(error_message)
+        raise locust.exception.RescheduleTask
 
     return code
 
@@ -52,15 +62,15 @@ def confirm_link(response):
     """
 
     dom = resp_to_dom(response)
-    try:
-        confirmation_link = dom.find("#confirm-now")[0].attrib["href"]
-    except Exception:
-        response.failure(
-            "Could not find CONFIRM NOW link, is IDP enable_load_testing_mode: 'true' ?"
-        )
+    error_message = (
+        "Could not find CONFIRM NOW link, is IDP enable_load_testing_mode: 'true' ?"
+    )
+    confirmation_link = dom.find("#confirm-now")[0].attrib["href"]
+    if not confirmation_link:
+        response.failure(error_message)
+        raise locust.exception.RescheduleTask
+
     return confirmation_link
-    
-        
 
 
 def resp_to_dom(resp):
@@ -95,21 +105,6 @@ def random_cred(num_users):
 
 
 """
-Format a common error message with full content attached
-"""
-
-
-def err_msg(msg, resp):
-    return """"
-           {}
-           Our current URL is: {}
-           Content is: {}.
-           """.format(
-        msg, resp.url, resp.content
-    )
-
-
-"""
 Use this in headers to act as a Desktop
 """
 
@@ -128,3 +123,5 @@ Raise errors when you are not at the expected page
 def verify_resp_url(url, resp):
     if url not in resp.url:
         resp.failure("You wanted {}, but got {} for a url".format(url, resp.url))
+        raise locust.exception.RescheduleTask
+

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -18,6 +18,8 @@ def do_request(
     ) as resp:
         if expected_redirect:
             verify_resp_url(expected_redirect, resp)
+
+        resp.raise_for_status()
         return resp
 
 
@@ -78,7 +80,6 @@ def resp_to_dom(resp):
     Little helper to check response status is 200
     and return the DOM, cause we do that a lot.
     """
-    resp.raise_for_status()
     return pyquery.PyQuery(resp.content)
 
 
@@ -121,7 +122,7 @@ Raise errors when you are not at the expected page
 
 
 def verify_resp_url(url, resp):
-    if url not in resp.url:
+    if resp.url and url not in resp.url:
         resp.failure("You wanted {}, but got {} for a url".format(url, resp.url))
         raise locust.exception.RescheduleTask
 

--- a/load_testing/common_flows/flow_ial2_proofing.py
+++ b/load_testing/common_flows/flow_ial2_proofing.py
@@ -118,12 +118,7 @@ def do_ial2_proofing(context):
         {"authenticity_token": auth_token, "otp_delivery_preference": "sms",},
     )
     auth_token = authenticity_token(resp)
-    try:
-        code = otp_code(resp)
-    except Exception:
-        resp.failure(
-            "Could not find pre-filled OTP code, is IDP telephony_adapter: 'test' ?"
-        )
+    code = otp_code(resp)
 
     # Verify SMS Delivery
     resp = do_request(

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -50,7 +50,5 @@ def do_sign_in(context):
         "/account",
         {"code": code, "authenticity_token": auth_token,},
     )
-    
-    resp.raise_for_status()
 
     return resp

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -42,17 +42,6 @@ def do_sign_in(context):
     auth_token = authenticity_token(resp)
     code = otp_code(resp)
 
-    if not code:
-        resp.failure(
-            """
-            No 2FA code found.
-            Make sure {} is created and can log into the IDP
-            """.format(
-                credentials
-            )
-        )
-        return
-
     # Post to unauthenticated redirect
     resp = do_request(
         context,
@@ -61,8 +50,7 @@ def do_sign_in(context):
         "/account",
         {"code": code, "authenticity_token": auth_token,},
     )
-    auth_token = authenticity_token(resp)
-
+    
     resp.raise_for_status()
 
     return resp

--- a/load_testing/common_flows/flow_sign_up.py
+++ b/load_testing/common_flows/flow_sign_up.py
@@ -6,6 +6,7 @@ from .flow_helper import (
     random_cred,
     do_request,
     confirm_link,
+    otp_code,
 )
 from .helper_phony import fake_phone_numbers
 import os
@@ -82,15 +83,7 @@ def do_sign_up(context):
         },
     )
     auth_token = authenticity_token(resp)
-
-    try:
-        dom = resp_to_dom(resp)
-        otp_code = dom.find('input[name="code"]')[0].attrib["value"]
-    except Exception:
-        resp.failure(
-            "Could not find pre-filled OTP code, is IDP telephony_adapter: 'test' ?"
-        )
-        return
+    code = otp_code(resp)
 
     # Visit security code page and submit pre-filled OTP
     resp = do_request(
@@ -98,7 +91,7 @@ def do_sign_up(context):
         "post",
         "/login/two_factor/sms",
         "/account",
-        {"code": otp_code, "authenticity_token": auth_token},
+        {"code": code, "authenticity_token": auth_token},
     )
 
 


### PR DESCRIPTION
When a locust runs into an error, immediately restart it.
This prevents the broken thread from continuing until the end of the flow, triggering more errors along the way.