### PR TITLE
Service provider (SP) Sign In flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ NUM_USERS=100 locust --locustfile load_testing/ial2_sign_up.locustfile.py --host
 ### SP Sign in load test
 
 - This requires that [`identity-oidc-sinatra`](https://github.com/18F/identity-oidc-sinatra) be running as an SP
+- This requires the `NUM_USERS` env varible
+- This requires the `SP_HOST` env varible, something like `SP_HOST=http://localhost:9292`
 
 ```sh
-NUM_USERS=100 locust --locustfile load_testing/sp_sign_in.locustfile.py --host http://localhost:3000 --clients 1 --hatch-rate 1 --run-time 15m --no-web
+NUM_USERS=100 SP_HOST=http://localhost:9292 locust --locustfile load_testing/sp_sign_in.locustfile.py --host http://localhost:3000 --clients 1 --hatch-rate 1 --run-time 15m --no-web
 ```
 
 ## Debugging Locust scripts

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ NUM_USERS=100 locust --locustfile load_testing/ial2_sign_in.locustfile.py --host
 NUM_USERS=100 locust --locustfile load_testing/ial2_sign_up.locustfile.py --host http://localhost:3000 --clients 1 --hatch-rate 1 --run-time 15m --no-web
 ```
 
+### SP Sign in load test
+
+- This requires that [`identity-oidc-sinatra`](https://github.com/18F/identity-oidc-sinatra) be running as an SP
+
+```sh
+NUM_USERS=100 locust --locustfile load_testing/sp_sign_in.locustfile.py --host http://localhost:3000 --clients 1 --hatch-rate 1 --run-time 15m --no-web
+```
+
 ## Debugging Locust scripts
 
 The HTTP Library is called Requests: <https://requests.readthedocs.io/en/master/>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ pip3 install -r requirements.txt
 Login IdP must be running with these settings in `application.yml`
 
 ```yml
+telephony_adapter: 'test'
 disable_email_sending: 'true'
 enable_load_testing_mode: 'true'
-telephony_adapter: 'test'
+enable_rate_limiting: 'false'
+otp_delivery_blocklist_maxretry: 1000000
 ```
 
 ## Running Locust

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -55,7 +55,16 @@ def authenticity_token(response, index=0):
     dom = resp_to_dom(response)
     token = dom.find(selector).eq(index).attr("value")
     if not token:
-        response.failure("Could not find authenticity_token on page")
+        error = "Could not find authenticity_token on page"
+        if os.getenv("DEBUG"):
+            message = """
+            {}
+            Response:
+                Body: {}
+            """.format(error, response.text)
+            response.failure(message)
+        else:
+            response.failure(error)
         raise locust.exception.RescheduleTask
 
     return token

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -62,8 +62,14 @@ def authenticity_token(response, index=0):
 
 
 def querystring_value(url, key):
+    # Get a querystring value from a url
     parsed = urllib.parse.urlparse(url)
     return urllib.parse.parse_qs(parsed.query)[key][0]
+
+
+def url_without_querystring(url):
+    # Return the url without a querystring
+    return url.split("?")[0]
 
 
 def otp_code(response):
@@ -102,6 +108,36 @@ def confirm_link(response):
     return confirmation_link
 
 
+def sp_signin_link(response):
+    """
+    Gets a Sign-in link from the SP, raises an error if not found
+    """
+
+    dom = resp_to_dom(response)
+    link = dom.find("div.sign-in-wrap a").eq(0)
+    href = link.attr("href")
+
+    if "/openid_connect/authorize" not in href:
+        response.failure("Could not find SP Sign in link")
+        raise locust.exception.RescheduleTask
+
+    return href
+
+def sp_signout_link(response):
+    """
+    Gets a Sign-in link from the SP, raises an error if not found
+    """
+
+    dom = resp_to_dom(response)
+    link = dom.find("div.sign-in-wrap a").eq(0)
+    href = link.attr("href")
+
+    if "/logout" not in href:
+        response.failure("Could not find SP Log out link")
+        raise locust.exception.RescheduleTask
+
+    return href
+
 def resp_to_dom(resp):
     """
     Little helper to check response status is 200
@@ -139,12 +175,19 @@ def random_phone():
     digits = "%0.4d" % randint(0,9999)
     return "202555" + digits
 
-"""
-Use this in headers to act as a Desktop
-"""
-
-
 def desktop_agent_headers():
+    """
+    Use this in headers to act as a Desktop
+    """
     return {
         "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"
     }
+
+def get_env(key):
+    """
+    Get an ENV value, and raise an error if it's not there
+    """
+    value = os.getenv(key)
+    if not value:
+        raise Exception("You must pass in Environment Variable {}".format(key))
+    return value

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -1,6 +1,7 @@
 import locust
 import os
 import pyquery
+import urllib
 from random import randint
 
 # Utility functions that are helpful in various locust contexts
@@ -60,6 +61,11 @@ def authenticity_token(response, index=0):
     return token
 
 
+def querystring_value(url, key):
+    parsed = urllib.parse.urlparse(url)
+    return urllib.parse.parse_qs(parsed.query)[key][0]
+
+
 def otp_code(response):
     """
     Retrieves the auto-populated OTP code from the DOM for submission.
@@ -71,6 +77,7 @@ def otp_code(response):
     )
 
     code = dom.find(selector).attr("value")
+
     if not code:
         response.failure(error_message)
         raise locust.exception.RescheduleTask

--- a/load_testing/common_flows/flow_ial2_proofing.py
+++ b/load_testing/common_flows/flow_ial2_proofing.py
@@ -1,6 +1,5 @@
 from faker import Faker
 from .flow_helper import do_request, authenticity_token, otp_code, random_phone
-import os
 import sys
 
 """

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -1,4 +1,3 @@
-import os
 from .flow_helper import (
     random_cred,
     resp_to_dom,

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -5,6 +5,7 @@ from .flow_helper import (
     authenticity_token,
     do_request,
     otp_code,
+    get_env,
 )
 
 """
@@ -15,7 +16,7 @@ from .flow_helper import (
 def do_sign_in(context):
 
     # This should match the number of users that were created for the DB with the rake task
-    num_users = os.environ.get("NUM_USERS")
+    num_users = get_env("NUM_USERS")
     credentials = random_cred(num_users)
 
     resp = do_request(context, "get", "/", "/")

--- a/load_testing/common_flows/flow_sign_up.py
+++ b/load_testing/common_flows/flow_sign_up.py
@@ -92,5 +92,4 @@ def do_sign_up(context):
         {"code": code, "authenticity_token": auth_token},
     )
 
-
     return resp

--- a/load_testing/common_flows/flow_sign_up.py
+++ b/load_testing/common_flows/flow_sign_up.py
@@ -8,7 +8,6 @@ from .flow_helper import (
     otp_code,
     random_phone
 )
-import os
 
 """
 *** Sign Up Flow ***

--- a/load_testing/common_flows/flow_sp_sign_in.py
+++ b/load_testing/common_flows/flow_sp_sign_in.py
@@ -1,0 +1,91 @@
+from .flow_helper import (
+    authenticity_token,
+    do_request,
+    get_env,
+    otp_code,
+    querystring_value,
+    random_cred,
+    sp_signin_link,
+    sp_signout_link,
+    url_without_querystring,
+)
+"""
+*** Service Provider Sign In Flow ***
+
+Using this flow requires that a Service Provider be running and configured to work with HOST
+"""
+
+def do_sp_sign_in(context):
+
+  sp_root_url = get_env("SP_HOST")
+
+  # GET the SP root, which should contain a login link, give it a friendly name for output
+  resp = do_request(
+      context, "get", sp_root_url, sp_root_url, {}, {}, sp_root_url
+  )
+  signin_link = sp_signin_link(resp)
+
+  # GET the signin link we found
+  resp = do_request(
+      context,
+      "get",
+      signin_link,
+      "/?request_id=",
+      {},
+      {},
+      url_without_querystring(signin_link),
+  )
+  auth_token = authenticity_token(resp)
+  request_id = querystring_value(resp.url, "request_id")
+
+  # POST username and password
+  num_users = get_env("NUM_USERS")
+  credentials = random_cred(num_users)
+  resp = do_request(
+      context,
+      "post",
+      "/",
+      "/login/two_factor/sms",
+      {
+          "user[email]": credentials["email"],
+          "user[password]": credentials["password"],
+          "user[request_id]": request_id,
+          "authenticity_token": auth_token,
+      },
+  )
+  auth_token = authenticity_token(resp)
+  code = otp_code(resp)
+
+  # POST to 2FA
+  # If first time for user, this redirects to "completed", otherwise to the SP root.
+  resp = do_request(
+      context,
+      "post",
+      "/login/two_factor/sms",
+      None,
+      {"code": code, "authenticity_token": auth_token,},
+  )
+
+  if "/sign_up/completed" in resp.url:
+      # POST to completed, should go back to the SP
+      auth_token = authenticity_token(resp)
+      resp = do_request(
+          context,
+          "post",
+          "/sign_up/completed",
+          sp_root_url,
+          {"authenticity_token": auth_token,},
+      )
+
+  # We should now be at the SP root, with a "logout" link.
+  # The test SP goes back to the root, so we'll test that for now
+  logout_link = sp_signout_link(resp)
+  do_request(
+      context,
+      "get",
+      logout_link,
+      sp_root_url,
+      {},
+      {},
+      url_without_querystring(logout_link),
+  )

--- a/load_testing/ial2_sign_in.locustfile.py
+++ b/load_testing/ial2_sign_in.locustfile.py
@@ -1,4 +1,3 @@
-import os
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_ial2_proofing, flow_sign_in, flow_helper
 

--- a/load_testing/ial2_sign_in.locustfile.py
+++ b/load_testing/ial2_sign_in.locustfile.py
@@ -7,7 +7,7 @@ class IAL2SignInLoad(TaskSet):
     def on_start(self):
         print(
             "*** Starting Sign-In and IAL2 proof load tests with "
-            + os.environ.get("NUM_USERS")
+            + flow_helper.get_env("NUM_USERS")
             + " users ***"
         )
 

--- a/load_testing/ial2_sign_up.locustfile.py
+++ b/load_testing/ial2_sign_up.locustfile.py
@@ -1,4 +1,3 @@
-import os
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_ial2_proofing, flow_sign_up, flow_helper
 

--- a/load_testing/sign_in.locustfile.py
+++ b/load_testing/sign_in.locustfile.py
@@ -1,4 +1,3 @@
-import os
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_sign_in, flow_helper
 

--- a/load_testing/sign_in.locustfile.py
+++ b/load_testing/sign_in.locustfile.py
@@ -7,7 +7,7 @@ class SignInLoad(TaskSet):
     def on_start(self):
         print(
             "*** Starting Sign-In load tests with "
-            + os.environ.get("NUM_USERS")
+            + flow_helper.get_env("NUM_USERS")
             + " users ***"
         )
 

--- a/load_testing/sign_up_sign_in.locustfile.py
+++ b/load_testing/sign_up_sign_in.locustfile.py
@@ -1,4 +1,3 @@
-import os
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_sign_in, flow_sign_up, flow_helper
 

--- a/load_testing/sp_sign_in.locustfile.py
+++ b/load_testing/sp_sign_in.locustfile.py
@@ -1,0 +1,68 @@
+import os
+from locust import HttpLocust, TaskSet, task, between
+from common_flows import flow_helper
+
+
+class SPSignInLoad(TaskSet):
+    @task(1)
+    def sp_sign_in_load_test(self):
+
+        #TODO: make this an ENV variable.  Others too?
+        sp_root_url = "http://localhost:9292"
+
+        # GET the SP root, which should contain a login link
+        resp = flow_helper.do_request(
+            self, "get", sp_root_url, sp_root_url, {}, {}, sp_root_url
+        )
+        dom = flow_helper.resp_to_dom(resp)
+        sp_signin_link = dom.find("div.sign-in-wrap a").eq(0).attr("href")
+        if not sp_signin_link:
+            resp.failure("We could not find a signin link at {}".format(resp.url))
+
+        # GET the signin link we found
+        redirect_match = self.parent.host + "/?request_id="
+        resp = flow_helper.do_request(
+            self, "get", sp_signin_link, redirect_match, {}, {}, redirect_match
+        )
+        auth_token = flow_helper.authenticity_token(resp)
+        request_id = flow_helper.querystring_value(resp.url, "request_id")
+
+        print("*** *** *** Request ID {}".format(request_id))
+
+        #TODO: this doesn't work from locust like it does when I do it manually.
+        # POST to the sign-in page
+        num_users = os.environ.get("NUM_USERS")
+        credentials = flow_helper.random_cred(num_users)
+        resp = flow_helper.do_request(
+            self,
+            "post",
+            "/",
+            "/login/two_factor/authenticator",
+            {
+                "user[email]": credentials["email"],
+                "user[password]": credentials["password"],
+                "user[request_id]": request_id,
+                "authenticity_token": auth_token,
+            },
+        )
+        print(resp.text)
+        auth_token = flow_helper.authenticity_token(resp)
+        code = flow_helper.otp_code(resp)
+
+        # POST to 2FA authenticator
+        resp = flow_helper.do_request(
+            self,
+            "post",
+            "/login/two_factor/authenticator",
+            "/account",
+            {"code": code, "authenticity_token": auth_token,},
+        )
+
+        # Get /account to prove login, then log out
+        flow_helper.do_request(self, "get", "/account", "/account")
+        flow_helper.do_request(self, "get", "/logout", "/")
+
+
+class WebsiteUser(HttpLocust):
+    task_set = SPSignInLoad
+    wait_time = between(5, 9)

--- a/load_testing/sp_sign_in.locustfile.py
+++ b/load_testing/sp_sign_in.locustfile.py
@@ -1,4 +1,3 @@
-import os
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_helper
 
@@ -43,7 +42,6 @@ class SPSignInLoad(TaskSet):
                 "authenticity_token": auth_token,
             },
         )
-
         auth_token = flow_helper.authenticity_token(resp)
         code = flow_helper.otp_code(resp)
 
@@ -56,10 +54,10 @@ class SPSignInLoad(TaskSet):
             None,
             {"code": code, "authenticity_token": auth_token,},
         )
-        auth_token = flow_helper.authenticity_token(resp)
 
         if "/sign_up/completed" in resp.url:
             # POST to completed, should go back to the SP
+            auth_token = flow_helper.authenticity_token(resp)
             resp = flow_helper.do_request(
                 self,
                 "post",

--- a/load_testing/sp_sign_in.locustfile.py
+++ b/load_testing/sp_sign_in.locustfile.py
@@ -1,83 +1,12 @@
 from locust import HttpLocust, TaskSet, task, between
-from common_flows import flow_helper
+from common_flows import flow_sp_sign_in
 
 
 class SPSignInLoad(TaskSet):
     @task(1)
     def sp_sign_in_load_test(self):
-
-        sp_root_url = flow_helper.get_env("SP_HOST")
-
-        # GET the SP root, which should contain a login link, give it a friendly name for output
-        resp = flow_helper.do_request(
-            self, "get", sp_root_url, sp_root_url, {}, {}, sp_root_url
-        )
-        signin_link = flow_helper.sp_signin_link(resp)
-
-        # GET the signin link we found
-        resp = flow_helper.do_request(
-            self,
-            "get",
-            signin_link,
-            "/?request_id=",
-            {},
-            {},
-            flow_helper.url_without_querystring(signin_link),
-        )
-        auth_token = flow_helper.authenticity_token(resp)
-        request_id = flow_helper.querystring_value(resp.url, "request_id")
-
-        # POST username and password
-        num_users = flow_helper.get_env("NUM_USERS")
-        credentials = flow_helper.random_cred(num_users)
-        resp = flow_helper.do_request(
-            self,
-            "post",
-            "/",
-            "/login/two_factor/sms",
-            {
-                "user[email]": credentials["email"],
-                "user[password]": credentials["password"],
-                "user[request_id]": request_id,
-                "authenticity_token": auth_token,
-            },
-        )
-        auth_token = flow_helper.authenticity_token(resp)
-        code = flow_helper.otp_code(resp)
-
-        # POST to 2FA
-        # If first time for user, this redirects to "completed", otherwise to the SP root.
-        resp = flow_helper.do_request(
-            self,
-            "post",
-            "/login/two_factor/sms",
-            None,
-            {"code": code, "authenticity_token": auth_token,},
-        )
-
-        if "/sign_up/completed" in resp.url:
-            # POST to completed, should go back to the SP
-            auth_token = flow_helper.authenticity_token(resp)
-            resp = flow_helper.do_request(
-                self,
-                "post",
-                "/sign_up/completed",
-                sp_root_url,
-                {"authenticity_token": auth_token,},
-            )
-
-        # We should now be at the SP root, with a "logout" link.
-        # Test SP goes back to the root, so we'll test that for now
-        logout_link = flow_helper.sp_signout_link(resp)
-        flow_helper.do_request(
-            self,
-            "get",
-            logout_link,
-            sp_root_url,
-            {},
-            {},
-            flow_helper.url_without_querystring(logout_link),
-        )
+        # This flow does its own SP logout
+        flow_sp_sign_in.do_sp_sign_in(self)
 
 
 class WebsiteUser(HttpLocust):


### PR DESCRIPTION
This adds a flow for SP logins.  

It requires that a Service Provider host is:
- running
- configured to work with the IdP host
- passed in via `SP_HOST` env variable

Right now this probably only works with <https://github.com/18F/identity-oidc-sinatra>.
If that's not what we run in real life, we can generalize things a bit more later.

Closes https://github.com/18F/identity-devops/issues/2249