### PR TITLE
Preload driver's license image data

### DIFF
--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -200,3 +200,25 @@ def get_env(key):
     if not value:
         raise Exception("You must pass in Environment Variable {}".format(key))
     return value
+
+def load_fixture(filename, path="./load_testing"):
+    """
+    Preload data for use by tests.
+
+    Args:
+        filename (str) - File to load, relative to path
+        path (str)     - (Optional)  Path files are under
+                        (Default: ./load_testing)
+    Returns:
+        bytes
+    """
+    fullpath = os.path.join(path, filename)
+
+    try:
+        with open(fullpath, "rb") as infile:
+            fixture = infile.read()
+    except FileNotFoundError:
+        # Be a little more helpful
+        raise RuntimeError(f"Could not find fixture {fullpath}")
+
+    return fixture

--- a/load_testing/common_flows/flow_ial2_proofing.py
+++ b/load_testing/common_flows/flow_ial2_proofing.py
@@ -8,7 +8,11 @@ import sys
 
 
 def do_ial2_proofing(context):
-
+    """
+    Requires following attributes on context:
+    * license_front - Image data for front of driver's license
+    * license_back - Image data for back of driver's license
+    """
     # Request IAL2 Verification
     resp = do_request(context, "get", "/verify", "/verify/doc_auth")
     auth_token = authenticity_token(resp)
@@ -34,28 +38,24 @@ def do_ial2_proofing(context):
     auth_token = authenticity_token(resp)
 
     # Post the Front Image of the license
-    front_path = sys.path[0] + "/load_testing/mont-front.jpeg"
-    image = open(front_path, "rb")
     resp = do_request(
         context,
         "put",
         "/verify/doc_auth/front_image",
         "/verify/doc_auth/back_image",
         {"authenticity_token": auth_token,},
-        {"doc_auth[image]": image},
+        {"doc_auth[image]": context.license_front},
     )
     auth_token = authenticity_token(resp)
 
     # Post the Back Image of the license
-    back_path = sys.path[0] + "/load_testing/mont-back.jpeg"
-    image = open(back_path, "rb")
     resp = do_request(
         context,
         "put",
         "/verify/doc_auth/back_image",
         "/verify/doc_auth/ssn",
         {"authenticity_token": auth_token,},
-        {"doc_auth[image]": image},
+        {"doc_auth[image]": context.license_back},
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/ial2_sign_in.locustfile.py
+++ b/load_testing/ial2_sign_in.locustfile.py
@@ -3,6 +3,10 @@ from common_flows import flow_ial2_proofing, flow_sign_in, flow_helper
 
 
 class IAL2SignInLoad(TaskSet):
+    # Preload drivers license data
+    license_front = flow_helper.load_fixture("mont-front.jpeg")
+    license_back = flow_helper.load_fixture("mont-back.jpeg")
+
     def on_start(self):
         print(
             "*** Starting Sign-In and IAL2 proof load tests with "

--- a/load_testing/ial2_sign_up.locustfile.py
+++ b/load_testing/ial2_sign_up.locustfile.py
@@ -3,6 +3,10 @@ from common_flows import flow_ial2_proofing, flow_sign_up, flow_helper
 
 
 class IAL2SignUpLoad(TaskSet):
+    # Preload drivers license data
+    license_front = flow_helper.load_fixture("mont-front.jpeg")
+    license_back = flow_helper.load_fixture("mont-back.jpeg")
+
     def on_start(self):
         print("*** Starting Sign-Up and IAL2 proof load tests ***")
 

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -13,6 +13,7 @@ from common_flows.flow_helper import (
     confirm_link,
     desktop_agent_headers,
     get_env,
+    load_fixture,
     otp_code,
     querystring_value,
     random_cred,
@@ -103,3 +104,10 @@ def test_sp_signout_link():
     with pytest.raises(Exception):
         sp_signout_link("A response without a sign-out link")
 
+def test_load_file():
+    orig = open("README.md", "rb").read()
+
+    assert load_fixture("README.md", ".") == orig
+
+    with pytest.raises(RuntimeError):
+        load_fixture("NotReallyThere")


### PR DESCRIPTION
Prevents file descriptor starvation due to many concurrent Locust
processes holding open file descriptors while POSTing data.