### PR TITLE
Add option for sign_in flow to remember device, skip OTP on future runs

### DIFF
--- a/load_testing/sign_in_remember_me.locustfile.py
+++ b/load_testing/sign_in_remember_me.locustfile.py
@@ -1,0 +1,34 @@
+from locust import HttpLocust, TaskSet, task, between
+from common_flows import flow_sign_in, flow_helper
+
+
+class SignInRememberMeLoad(TaskSet):
+    def on_start(self):
+        print(
+            "*** Starting Sign-In Remember Me load tests with "
+            + flow_helper.get_env("NUM_USERS")
+            + " users ***"
+        )
+
+    def on_stop(self):
+        print("*** Ending Sign-In load tests ***")
+
+    """ @task(<weight>) : value=3 executes 3x as often as value=1 """
+    """ Things inside task are synchronous. Tasks are async """
+
+    @task(1)
+    def sign_in_load_test(self):
+
+        # Do Sign In and make sure to check "Remember Device"
+        flow_sign_in.do_sign_in(self, remember_device = True)
+
+        # Get the /account page now
+        flow_helper.do_request(self, "get", "/account", "/account")
+
+        # Now log out
+        flow_helper.do_request(self, "get", "/logout", "/")
+
+
+class WebsiteUser(HttpLocust):
+    task_set = SignInRememberMeLoad
+    wait_time = between(5, 9)


### PR DESCRIPTION
For https://github.com/18F/identity-devops/issues/2416

Locally this seems to work, it only hits the `/sms` path once compared to the sign_in flow which hits it every time