### PR TITLE
Add persistent cookie handling for remembered device sign in

### DIFF
--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -208,7 +208,8 @@ def choose_cred(choose_from):
 
 def use_previous_visitor(visited_count, visited_min, remembered_target):
     """
-    Helper to decide if a specific sign in should use a previously used used.
+    Helper to decide if a specific sign in should use a previously used user
+    number.
 
     Args:
         visited_count (int)       - Number of previously visited users

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -1,4 +1,4 @@
-from requests.utils import urlparse
+from urllib.parse import urlparse
 from .flow_helper import (
     authenticity_token,
     choose_cred,

--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -1,30 +1,54 @@
+from requests.utils import urlparse
 from .flow_helper import (
+    authenticity_token,
+    choose_cred,
+    do_request,
+    export_cookies,
+    get_env,
+    import_cookies,
+    otp_code,
     random_cred,
     resp_to_dom,
-    authenticity_token,
-    do_request,
-    otp_code,
-    get_env,
+    use_previous_visitor,
 )
+
 
 """
 *** Sign In Flow ***
 """
 
-def do_sign_in(context, remember_device = False):
 
+def do_sign_in(
+    context, remember_device=False, visited={}, visited_min=0, remembered_target=0,
+):
+    remembered = False
     # This should match the number of users that were created for the DB with the rake task
     num_users = get_env("NUM_USERS")
-    credentials = random_cred(num_users)
+
+    # Crossed minimum visited user threshold AND passed random selector
+    if remember_device and use_previous_visitor(
+        len(visited), visited_min, remembered_target
+    ):
+        # Choose a specific previous user
+        credentials = choose_cred(visited.keys())
+        # Restore remembered device cookies to client jar
+        import_cookies(context.client, visited[credentials["number"]])
+        remembered = True
+
+    else:
+        # Choose a random user
+        credentials = random_cred(num_users)
+
+    usernum = credentials["number"]
 
     resp = do_request(context, "get", "/", "/")
     auth_token = authenticity_token(resp)
 
     if "/account" in resp.url:
-        print("You're already logged in. Quitting sign-in.")
+        print(f"You're already logged in. Quitting sign-in for {usernum}")
         return resp
 
-    expected_path = "/login/two_factor/sms" if remember_device == False else None
+    expected_path = "/login/two_factor/sms" if remember_device is False else None
 
     # Post login credentials
     resp = do_request(
@@ -40,8 +64,11 @@ def do_sign_in(context, remember_device = False):
     )
 
     if "/account" in resp.url:
-        print("You're already logged in. Quitting sign-in.")
+        if not remembered:
+            print(f"You're already logged in. Quitting sign-in for {usernum}")
         return resp
+
+    remembered and print(f"Unexpected SMS prompt for remembered user {usernum}")
 
     auth_token = authenticity_token(resp)
     code = otp_code(resp)
@@ -59,13 +86,18 @@ def do_sign_in(context, remember_device = False):
         },
     )
 
+    # Mark user as visited and save remembered device cookies
+    visited[usernum] = export_cookies(urlparse(resp.url).netloc, context.client.cookies)
+
     return resp
+
 
 def remember_device_value(value):
     if value:
         return "true"
     else:
         return "false"
+
 
 def do_sign_in_user_not_found(context):
     num_users = get_env("NUM_USERS")
@@ -121,7 +153,7 @@ def do_sign_in_incorrect_password(context):
     return resp
 
 
-def do_sign_in_incorrect_otp(context):
+def do_sign_in_incorrect_sms_otp(context):
     num_users = get_env("NUM_USERS")
     credentials = random_cred(num_users)
 
@@ -152,7 +184,7 @@ def do_sign_in_incorrect_otp(context):
         "post",
         "/login/two_factor/sms",
         "/login/two_factor/sms",
-        {"code": "000000", "authenticity_token": auth_token,},
+        {"code": "000000", "authenticity_token": auth_token},
     )
 
     return resp

--- a/load_testing/sign_in_failure.locustfile.py
+++ b/load_testing/sign_in_failure.locustfile.py
@@ -26,10 +26,10 @@ class SignInFailureLoad(TaskSet):
         flow_sign_in.do_sign_in_incorrect_password(self)
 
     @task(1)
-    def sign_in_load_test_incorrect_otp(self):
+    def sign_in_load_test_incorrect_sms_otp(self):
 
         # Do Sign In
-        flow_sign_in.do_sign_in_incorrect_otp(self)
+        flow_sign_in.do_sign_in_incorrect_sms_otp(self)
 
 
 class WebsiteUser(HttpLocust):

--- a/load_testing/sign_in_remember_me.locustfile.py
+++ b/load_testing/sign_in_remember_me.locustfile.py
@@ -1,14 +1,30 @@
 from locust import HttpLocust, TaskSet, task, between
 from common_flows import flow_sign_in, flow_helper
 
+# Singletons... everyone's fav!
+VISITED = {}
 
 class SignInRememberMeLoad(TaskSet):
     def on_start(self):
-        print(
-            "*** Starting Sign-In Remember Me load tests with "
-            + flow_helper.get_env("NUM_USERS")
-            + " users ***"
-        )
+
+        num_users = int(flow_helper.get_env("NUM_USERS"))
+
+        print(f"*** Starting Sign-In Remember Me load tests with {num_users} users ***")
+
+        # Create a tracking dictionary to allow selection of previously logged
+        # in users and restoration on specific cookies
+        self.visited = VISITED
+
+        # TODO - Make these tunable
+        # Wait till this percentage of users have visited before enabling
+        # random visited user selection.
+        self.visited_min_pct = 1
+
+        # Target percentage of remembered users
+        self.remembered_target = 90
+
+        # Calculate minimum number based on passed users
+        self.visited_min = int(0.01 * self.visited_min_pct * num_users)
 
     def on_stop(self):
         print("*** Ending Sign-In load tests ***")
@@ -20,7 +36,13 @@ class SignInRememberMeLoad(TaskSet):
     def sign_in_load_test(self):
 
         # Do Sign In and make sure to check "Remember Device"
-        flow_sign_in.do_sign_in(self, remember_device = True)
+        flow_sign_in.do_sign_in(
+            self,
+            remember_device=True,
+            visited=self.visited,
+            visited_min=self.visited_min,
+            remembered_target=self.remembered_target,
+        )
 
         # Get the /account page now
         flow_helper.do_request(self, "get", "/account", "/account")

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -1,15 +1,17 @@
-
 import pytest
 import os
 import re
 import test_helper
 
 # Import load_testing files
-# :/ this kind of import only works when you run `pytest` from the root of the project.
+# :/ this kind of import only works when you run `pytest` from the root
+# of the project.
 import sys
-sys.path.append('./load_testing')
+
+sys.path.append("./load_testing")
 from common_flows.flow_helper import (
     authenticity_token,
+    choose_cred,
     confirm_link,
     desktop_agent_headers,
     get_env,
@@ -22,33 +24,71 @@ from common_flows.flow_helper import (
     sp_signin_link,
     sp_signout_link,
     url_without_querystring,
+    use_previous_visitor,
 )
 
 """
 *** Unit test simple flow helpers
 """
 
+
 def test_querystring_value():
     url = "http://one.two?three=four&five=six"
     assert querystring_value(url, "three") == "four"
     assert querystring_value(url, "five") == "six"
 
+
 def test_url_without_querystring():
-    assert url_without_querystring("http://one.two?three=four&five=six") == "http://one.two"
+    assert (
+        url_without_querystring("http://one.two?three=four&five=six")
+        == "http://one.two"
+    )
     assert url_without_querystring("http://one.two") == "http://one.two"
+
 
 def test_random_cred():
     cred = random_cred(1)
+    assert cred["number"] == 0
     assert cred["email"] == "testuser0@example.com"
     assert cred["password"] == "salty pickles"
+
+
+def test_choose_cred():
+    choices = [777, 424242, 90210]
+    cred = choose_cred(choices)
+    number = cred["number"]
+    assert number in choices
+    assert cred["email"] == "testuser{}@example.com".format(number)
+    assert cred["password"] == "salty pickles"
+
+
+def test_use_previous_visitor():
+    # Under threshold should always be false
+    assert use_previous_visitor(0, 1, 0) is False
+
+    # Over threshold with a 100% limit should always be true
+    assert use_previous_visitor(1, 0, 100) is True
+
+    # Nondeterministic test with 75% target +/- 10% and 1000 samples
+    trues = 0
+    for i in range(1000):
+        if use_previous_visitor(1, 0, 75):
+            trues = trues + 1
+
+    assert (
+        trues >= 650 and trues <= 850
+    ), "use_previous_visitor with target of 75% +/- 10 was out of spec"
+
 
 def test_random_phone():
     for i in range(5):
         assert re.match(r"202555\d{4}", random_phone())
 
+
 def test_desktop_agent_headers():
     agent = desktop_agent_headers()
     assert "Firefox" in agent["User-Agent"]
+
 
 def test_get_env():
     os.environ["TESTKEY"] = "testvalue"
@@ -57,20 +97,35 @@ def test_get_env():
     with pytest.raises(Exception):
         get_env("UNSETKEY")
 
+
 def test_resp_to_dom():
     resp = test_helper.mock_response("doc_auth_verify.html")
     assert resp_to_dom(resp)
 
+
 def test_authentication_token():
     resp = test_helper.mock_response("doc_auth_verify.html")
 
-    assert authenticity_token(resp) == "WPhfbuwqPzfbpB2+aTHWR93t0/7O88iK5nYdL/RaZoLEPH63Cjf4yKAkHw6CUDyaXw6O5oi4Nc2NHzC6stEdwA=="
-    assert authenticity_token(resp, 0)  == "WPhfbuwqPzfbpB2+aTHWR93t0/7O88iK5nYdL/RaZoLEPH63Cjf4yKAkHw6CUDyaXw6O5oi4Nc2NHzC6stEdwA=="
-    assert authenticity_token(resp, 1) == "I7WOA3x24rsZVj56R9QtCNVNlXapxqo2A9MOkU2sHPIsAi99KMzwSzD3Y89H710hluHXCoKOYt8VkT77f9U/Kg=="
-    assert authenticity_token(resp, 2) == "679gwHHowpDvKlzyBL4Cw2MYZC1NYLqWaAEz+Nze6ZJZELBdu1t7BTlGmVkvqfBh713/xc0oCkbndTMoOlpLRg=="
+    assert (
+        authenticity_token(resp)
+        == "WPhfbuwqPzfbpB2+aTHWR93t0/7O88iK5nYdL/RaZoLEPH63Cjf4yKAkHw6CUDyaXw6O5oi4Nc2NHzC6stEdwA=="
+    )
+    assert (
+        authenticity_token(resp, 0)
+        == "WPhfbuwqPzfbpB2+aTHWR93t0/7O88iK5nYdL/RaZoLEPH63Cjf4yKAkHw6CUDyaXw6O5oi4Nc2NHzC6stEdwA=="
+    )
+    assert (
+        authenticity_token(resp, 1)
+        == "I7WOA3x24rsZVj56R9QtCNVNlXapxqo2A9MOkU2sHPIsAi99KMzwSzD3Y89H710hluHXCoKOYt8VkT77f9U/Kg=="
+    )
+    assert (
+        authenticity_token(resp, 2)
+        == "679gwHHowpDvKlzyBL4Cw2MYZC1NYLqWaAEz+Nze6ZJZELBdu1t7BTlGmVkvqfBh713/xc0oCkbndTMoOlpLRg=="
+    )
 
     with pytest.raises(Exception):
         authenticity_token("a response without a token in it")
+
 
 def test_otp_code():
     resp = test_helper.mock_response("two_factor_sms.html")
@@ -80,21 +135,24 @@ def test_otp_code():
     with pytest.raises(Exception):
         otp_code("a response without a code in it")
 
+
 def test_confirm_link():
     resp = test_helper.mock_response("verify_email.html")
 
     assert "/sign_up/email/confirm?confirmation_token=" in confirm_link(resp)
-    
+
     with pytest.raises(Exception):
         confirm_link("a response without a token in it")
 
+
 def test_sp_signin_link():
     resp = test_helper.mock_response("sp_without_session.html")
-    
+
     assert "openid_connect/authorize?" in sp_signin_link(resp)
 
     with pytest.raises(Exception):
         sp_signin_link("a response without a signin link in it")
+
 
 def test_sp_signout_link():
     resp = test_helper.mock_response("sp_with_session.html")
@@ -103,6 +161,7 @@ def test_sp_signout_link():
 
     with pytest.raises(Exception):
         sp_signout_link("A response without a sign-out link")
+
 
 def test_load_file():
     orig = open("README.md", "rb").read()


### PR DESCRIPTION
* sign_in helper records users as they visit, then starts replaying after
  threhold is met, attempting to hit remembered sign in target.
* sign_in helper uses per-user cookie cache to restore
  "user_opted_remember_device_preference" and "remember_device"
  cookies for a given user.

Able to push over 90% remembered device mix.