### PR TITLE
SP sign in method updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ enable_rate_limiting: 'false'
 otp_delivery_blocklist_maxretry: 1000000
 ```
 
+Note that it's also important to assure that the scrypt cost is configured the same as prod. The values will
+inherit from the [idp-repo](https://github.com/18F/identity-idp/blob/master/config/application.yml.default) unless the values are overridden in the secrets s3 bucket.
+
 ## Running Locust
 
 You can only run one locustfile at a time, there are many to choose from that end in `.locustfile.py`.
@@ -56,7 +59,7 @@ locust --locustfile load_testing/sign_up.locustfile.py --host http://localhost:3
 
 ### Sign-In load test
 
-- You must run a rake task in the IdP before using this test, something like: `rake dev:random_users NUM_USERS=100 SCRYPT_COST='800$8$1$'` [(source)](https://github.com/18F/identity-idp/blob/master/lib/tasks/dev.rake)
+- You must run a rake task in the IdP before using this test, something like: `rake dev:random_users NUM_USERS=100` [(source)](https://github.com/18F/identity-idp/blob/master/lib/tasks/dev.rake)
 - You also must pass in a matching `NUM_USERS=100` to the locust call.
 
 ```sh
@@ -68,7 +71,7 @@ NUM_USERS=100 locust --locustfile load_testing/sign_in.locustfile.py --host http
 Tests sign ins simulating a very high (90%) ratio of users who are signing back
 in using a remembered browser (device).
 
-- You must run a rake task in the IdP before using this test, something like: `rake dev:random_users NUM_USERS=100 SCRYPT_COST='800$8$1$'` [(source)](https://github.com/18F/identity-idp/blob/master/lib/tasks/dev.rake)
+- You must run a rake task in the IdP before using this test, something like: `rake dev:random_users NUM_USERS=100'` [(source)](https://github.com/18F/identity-idp/blob/master/lib/tasks/dev.rake)
 - You also must pass in a matching `NUM_USERS=100` to the locust call.
 
 ```sh

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -10,6 +10,7 @@ DEFAULT_COOKIE_SAVELIST = [
     "remember_device"
 ]
 
+
 def do_request(
     context, method, path, expected_redirect=None, data={}, files={}, name=None
 ):
@@ -132,6 +133,7 @@ def sp_signin_link(response):
     """
 
     dom = resp_to_dom(response)
+
     link = dom.find("div.sign-in-wrap a").eq(0)
     href = link.attr("href")
 
@@ -215,7 +217,7 @@ def use_previous_visitor(visited_count, visited_min, remembered_target):
         visited_count (int)       - Number of previously visited users
         visited_min (int)         - Lower threshold of visited users before reuse
         remembered_target (float) - Target percentage of reuse
-    
+
     Returns:
         bool
     """

--- a/load_testing/common_flows/flow_helper.py
+++ b/load_testing/common_flows/flow_helper.py
@@ -169,7 +169,7 @@ def resp_to_dom(resp):
 def random_cred(num_users):
     """
     Given the rake task:
-    rake dev:random_users NUM_USERS=1000 SCRYPT_COST='800$8$1$'
+    rake dev:random_users NUM_USERS=1000'
 
     We should have 1000 existing users with credentials matching:
     * email address testuser1@example.com through testuser1000@example.com

--- a/load_testing/common_flows/flow_sp_sign_in.py
+++ b/load_testing/common_flows/flow_sp_sign_in.py
@@ -12,80 +12,89 @@ from .flow_helper import (
 """
 *** Service Provider Sign In Flow ***
 
-Using this flow requires that a Service Provider be running and configured to work with HOST
+Using this flow requires that a Service Provider be running and configured to work with HOST. It
+also requires that users are pre-generated in the IdP database.
 """
 
+
 def do_sp_sign_in(context):
+    sp_root_url = get_env("SP_HOST")
 
-  sp_root_url = get_env("SP_HOST")
+    # GET the SP root, which should contain a login link, give it a friendly name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
 
-  # GET the SP root, which should contain a login link, give it a friendly name for output
-  resp = do_request(
-      context, "get", sp_root_url, sp_root_url, {}, {}, sp_root_url
-  )
-  signin_link = sp_signin_link(resp)
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=1'
 
-  # GET the signin link we found
-  resp = do_request(
-      context,
-      "get",
-      signin_link,
-      "/?request_id=",
-      {},
-      {},
-      url_without_querystring(signin_link),
-  )
-  auth_token = authenticity_token(resp)
-  request_id = querystring_value(resp.url, "request_id")
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
 
-  # POST username and password
-  num_users = get_env("NUM_USERS")
-  credentials = random_cred(num_users)
-  resp = do_request(
-      context,
-      "post",
-      "/",
-      "/login/two_factor/sms",
-      {
-          "user[email]": credentials["email"],
-          "user[password]": credentials["password"],
-          "user[request_id]": request_id,
-          "authenticity_token": auth_token,
-      },
-  )
-  auth_token = authenticity_token(resp)
-  code = otp_code(resp)
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
 
-  # POST to 2FA
-  # If first time for user, this redirects to "completed", otherwise to the SP root.
-  resp = do_request(
-      context,
-      "post",
-      "/login/two_factor/sms",
-      None,
-      {"code": code, "authenticity_token": auth_token,},
-  )
+    # POST username and password
+    num_users = get_env("NUM_USERS")
+    credentials = random_cred(num_users)
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/login/two_factor/sms",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
 
-  if "/sign_up/completed" in resp.url:
-      # POST to completed, should go back to the SP
-      auth_token = authenticity_token(resp)
-      resp = do_request(
-          context,
-          "post",
-          "/sign_up/completed",
-          sp_root_url,
-          {"authenticity_token": auth_token,},
-      )
+    # POST to 2FA
+    # If first time for user, this redirects to "completed", otherwise to the SP root.
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        None,
+        {"code": code, "authenticity_token": auth_token, },
+    )
 
-  # We should now be at the SP root, with a "logout" link.
-  # The test SP goes back to the root, so we'll test that for now
-  logout_link = sp_signout_link(resp)
-  do_request(
-      context,
-      "get",
-      logout_link,
-      sp_root_url,
-      {},
-      {},
-      url_without_querystring(logout_link),
-  )
+    if "/sign_up/completed" in resp.url:
+        # POST to completed, should go back to the SP
+        auth_token = authenticity_token(resp)
+        resp = do_request(
+            context,
+            "post",
+            "/sign_up/completed",
+            sp_root_url,
+            {"authenticity_token": auth_token, },
+        )
+
+    # We should now be at the SP root, with a "logout" link.
+    # The test SP goes back to the root, so we'll test that for now
+    logout_link = sp_signout_link(resp)
+    do_request(
+        context,
+        "get",
+        logout_link,
+        sp_root_url,
+        {},
+        {},
+        url_without_querystring(logout_link),
+    )


### PR DESCRIPTION
This makes the changes needed to use the form based login button in the [sample SP app](https://github.com/18F/identity-oidc-sinatra). I also made some minor readme updates by adding a note about scrypt cost in the IdP config and removed the ` SCRYPT_COST='800$8$1$'`, which we don't want in the load test and did not seem to function correctly anyhow: https://gsa-tts.slack.com/archives/C010L0SE4E8/p1600987482033000.

I also used the default pylint settings to update the formatting of the modified files in this change.

These changes were made in support of https://github.com/18F/identity-devops/issues/2192

One can test these changes by running locally against the `pt` env:
```
NUM_USERS=10000 SP_HOST=https://sp-oidc-sinatra.pt.identitysandbox.gov/ locust --locustfile load_testing/sp_sign_in.locustfile.py --host https://idp.pt.identitysandbox.gov  --users 50 --hatch-rate 10 --run-time 10m --headless
```

example results
```
[2020-09-30 15:28:08,609] j12/INFO/locust.main: Time limit reached. Stopping Locust.
[2020-09-30 15:28:08,690] j12/INFO/locust.main: Running teardowns...
[2020-09-30 15:28:08,690] j12/INFO/locust.main: Shutting down (exit code 0), bye.
[2020-09-30 15:28:08,690] j12/INFO/locust.main: Cleaning up runner...
 Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 POST /                                                           590     0(0.00%)    1537    1328    2422  |    1500    0.98    0.00
 POST /login/two_factor/sms                                       566     0(0.00%)   16005     610   28656  |   19000    0.94    0.00
 POST /sign_up/completed                                           94     0(0.00%)   18730    7331   28998  |   20000    0.16    0.00
 GET https://idp.pt.identitysandbox.gov/openid_connect/logout     563     0(0.00%)   11885    5546   24241  |   10000    0.94    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/              607     0(0.00%)    4959     583   14040  |    4200    1.01    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request     594     0(0.00%)    6977    1031   14673  |    6800    0.99    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                      3014     0(0.00%)    8484     583   28998  |    6800    5.03    0.00

Percentage of the requests completed within given times
 Type                 Name                                                           # reqs    50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100%
------------------------------------------------------------------------------------------------------------------------------------------------------
 POST                 /                                                                 590   1500   1500   1600   1700   1700   1800   1900   2000   2400   2400   2400
 POST                 /login/two_factor/sms                                             566  19000  21000  21000  22000  23000  25000  27000  28000  29000  29000  29000
 POST                 /sign_up/completed                                                 94  20000  21000  22000  22000  23000  25000  28000  29000  29000  29000  29000
 GET                  https://idp.pt.identitysandbox.gov/openid_connect/logout          563  10000  13000  16000  17000  19000  20000  22000  23000  24000  24000  24000
 GET                  https://sp-oidc-sinatra.pt.identitysandbox.gov/                   607   4200   5200   6100   6700   8100  11000  12000  12000  14000  14000  14000
 GET                  https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request       594   6800   8500   9500   9900  11000  11000  12000  12000  15000  15000  15000
------------------------------------------------------------------------------------------------------------------------------------------------------
 None                 Aggregated                                                       3014   6800   9500  12000  16000  20000  22000  23000  25000  29000  29000  29000
```