### PR TITLE
Update IAL2 requests to match current IdP + pylint

### DIFF
--- a/load_testing/common_flows/flow_ial2_proofing.py
+++ b/load_testing/common_flows/flow_ial2_proofing.py
@@ -23,7 +23,7 @@ def do_ial2_proofing(context):
         "put",
         "/verify/doc_auth/welcome",
         "/verify/doc_auth/upload",
-        {"ial2_consent_given": "true", "authenticity_token": auth_token,},
+        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 
@@ -32,44 +32,24 @@ def do_ial2_proofing(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/front_image",
-        {"authenticity_token": auth_token,},
+        "/verify/doc_auth/document_capture",
+        {"authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 
-    # Post the Front Image of the license
+    files = {"doc_auth[front_image]": context.license_front,
+             "doc_auth[back_image]": context.license_back}
+
+    # Post the license images
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/front_image",
-        "/verify/doc_auth/back_image",
-        {"authenticity_token": auth_token,},
-        {"doc_auth[image]": context.license_front},
-    )
-    auth_token = authenticity_token(resp)
-
-    # Post the Back Image of the license
-    resp = do_request(
-        context,
-        "put",
-        "/verify/doc_auth/back_image",
-        "/verify/doc_auth/selfie",
-        {"authenticity_token": auth_token,},
-        {"doc_auth[image]": context.license_back},
-    )
-    auth_token = authenticity_token(resp)
-
-
-    # Post Selfie image
-    resp = do_request(
-        context,
-        "put",
-        "/verify/doc_auth/selfie",
+        "/verify/doc_auth/document_capture",
         "/verify/doc_auth/ssn",
-        {"authenticity_token": auth_token,},
-        {"doc_auth[image]": context.selfie},
+        {"authenticity_token": auth_token, },
+        files
     )
-    auth_token = authenticity_token(resp) 
+    auth_token = authenticity_token(resp)
 
     # SSN - use faker to get unique SSNs
     fake = Faker()
@@ -80,7 +60,7 @@ def do_ial2_proofing(context):
         "put",
         "/verify/doc_auth/ssn",
         "/verify/doc_auth/verify",
-        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn,},
+        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn, },
     )
     # There are three auth tokens on the response, get the second
     auth_token = authenticity_token(resp, 1)
@@ -90,18 +70,8 @@ def do_ial2_proofing(context):
         context,
         "put",
         "/verify/doc_auth/verify",
-        "/verify/doc_auth/doc_success",
-        {"authenticity_token": auth_token,},
-    )
-    auth_token = authenticity_token(resp)
-
-    # Continue after doc success
-    resp = do_request(
-        context,
-        "put",
-        "/verify/doc_auth/doc_success",
         "/verify/phone",
-        {"authenticity_token": auth_token,},
+        {"authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 
@@ -111,7 +81,8 @@ def do_ial2_proofing(context):
         "put",
         "/verify/phone",
         "/verify/otp_delivery_method",
-        {"authenticity_token": auth_token, "idv_phone_form[phone]": random_phone(),},
+        {"authenticity_token": auth_token,
+            "idv_phone_form[phone]": random_phone(), },
     )
     auth_token = authenticity_token(resp)
 
@@ -121,7 +92,7 @@ def do_ial2_proofing(context):
         "put",
         "/verify/otp_delivery_method",
         "/verify/phone_confirmation",
-        {"authenticity_token": auth_token, "otp_delivery_preference": "sms",},
+        {"authenticity_token": auth_token, "otp_delivery_preference": "sms", },
     )
     auth_token = authenticity_token(resp)
     code = otp_code(resp)
@@ -132,7 +103,7 @@ def do_ial2_proofing(context):
         "put",
         "/verify/phone_confirmation",
         "/verify/review",
-        {"authenticity_token": auth_token, "code": code,},
+        {"authenticity_token": auth_token, "code": code, },
     )
     auth_token = authenticity_token(resp)
 
@@ -142,7 +113,8 @@ def do_ial2_proofing(context):
         "put",
         "/verify/review",
         "/verify/confirmations",
-        {"authenticity_token": auth_token, "user[password]": "salty pickles",},
+        {"authenticity_token": auth_token,
+            "user[password]": "salty pickles", },
     )
     auth_token = authenticity_token(resp)
 
@@ -152,7 +124,7 @@ def do_ial2_proofing(context):
         "post",
         "/verify/confirmations",
         "/account",
-        {"authenticity_token": auth_token,},
+        {"authenticity_token": auth_token, },
     )
 
     # Re-Check verification activated

--- a/load_testing/ial2_sign_in.locustfile.py
+++ b/load_testing/ial2_sign_in.locustfile.py
@@ -28,7 +28,8 @@ class IAL2SignInLoad(TaskSet):
         flow_sign_in.do_sign_in(self)
 
         #  Get /account page
-        flow_helper.do_request(self, "get", "/account", "/account")
+        flow_helper.
+        (self, "get", "/account", "/account")
 
         # IAL2 Proofing flow
         flow_ial2_proofing.do_ial2_proofing(self)


### PR DESCRIPTION
This makes the changes needed to be on par with the IAL2 flows that exist in the [current version of the IdP](https://github.com/18F/identity-idp/commit/ba7164937e8eb851291014e377328039c71b0045). 


```
locust --host https://idp.pt.identitysandbox.gov --locustfile load_testing/ial2_sign_up.locustfile.py --users 100 --hatch-rate 1 --headless --csv ial2_sign_up
```

Note there are still errors with `GET                  /sign_up/enter_email` which I'll fix in a subsequent PR since it's not related to #27.

```
 Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /account                                                     134     0(0.00%)    4825     160   10310  |    5600    0.30    0.00
 POST /login/two_factor/sms                                       114     0(0.00%)    8944     344   18032  |   11000    0.26    0.00
 GET /logout                                                       20     0(0.00%)    5694     572   12681  |    5900    0.04    0.00
 GET /phone_setup                                                 116     0(0.00%)    4064     149   10401  |    4100    0.26    0.00
 POST /phone_setup                                                115     0(0.00%)   12488     475   23880  |   15000    0.26    0.00
 POST /sign_up/create_password                                    118     0(0.00%)    8540     721   17400  |    9200    0.27    0.00
 GET /sign_up/email/confirm?confirmation_token=                   120     0(0.00%)    6959     288   15490  |    7000    0.27    0.00
 GET /sign_up/enter_email                                         790  666(84.30%)     983     139    9533  |     500    1.78    1.50
 POST /sign_up/enter_email                                        123     0(0.00%)    7003     438   18066  |    6800    0.28    0.00
 GET /verify                                                      131     0(0.00%)   13700     451   24115  |   16000    0.29    0.00
 POST /verify/confirmations                                        24     0(0.00%)   11186    1134   16737  |   12000    0.05    0.00
 PUT /verify/doc_auth/document_capture                             73     0(0.00%)   10683     652   18788  |   12000    0.16    0.00
 PUT /verify/doc_auth/ssn                                          64     0(0.00%)   10239     321   17742  |   12000    0.14    0.00
 PUT /verify/doc_auth/upload?type=desktop                          88     0(0.00%)    9594     301   17163  |   12000    0.20    0.00
 PUT /verify/doc_auth/verify                                       49     0(0.00%)   21841    1282   34154  |   24000    0.11    0.00
 PUT /verify/doc_auth/welcome                                      97     0(0.00%)    9387     307   19883  |   11000    0.22    0.00
 PUT /verify/otp_delivery_method                                   36     0(0.00%)   10132     517   16802  |   11000    0.08    0.00
 PUT /verify/phone                                                 43     0(0.00%)   16879     997   25539  |   19000    0.10    0.00
 PUT /verify/phone_confirmation                                    29     0(0.00%)   10203     562   16800  |   12000    0.07    0.00
 PUT /verify/review                                                25     0(0.00%)   13410    3975   19642  |   14000    0.06    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                      2309  666(28.84%)    6589     139   34154  |    4800    5.19    1.50
```