### PR TITLE
Update requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.7
+      - image: circleci/python:3.7
     working_directory: ~/identity-loadtest
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__
 bin/
 include/
 lib/
-pyvenv.cf
+pyvenv.cfg
 
 # Test drivers license images
 mont-front.jpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-coverage==5.1
-Faker==4.1.0
-locust==1.0.3
-pyquery==1.4.1
-pytest==5.4.3
+coverage==5.4
+Faker==6.5.0
+locust==1.4.3
+pyquery==1.4.3
+pytest==6.2.2


### PR DESCRIPTION
Updates Locust and other primary dependencies and locks CircleCI to Python 3.7.x instead of a specific release.  The loadtests are run from a wide range of systems, hence use of Python 3.7 as the baseline.