### PR TITLE
Update faker to latest for python 3.9.4+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage==5.4
-Faker==6.5.0
+Faker==8.1.3
 locust==1.4.3
 pyquery==1.4.3
 pytest==6.2.2


### PR DESCRIPTION
Simple fix for https://gsa-tts.slack.com/archives/C010L0SE4E8/p1620861178002700

Tested on OSX https://gsa-tts.slack.com/archives/C010L0SE4E8/p1620864092005300 and on the jumphost: https://gsa-tts.slack.com/archives/C010L0SE4E8/p1620864574005900