### PR TITLE
Add SP Sign In and Sign Up methods to the prod_simulator fllow

### DIFF
--- a/load_testing/common_flows/flow_sign_in.py
+++ b/load_testing/common_flows/flow_sign_in.py
@@ -19,11 +19,16 @@ from .flow_helper import (
 
 
 def do_sign_in(
-    context, remember_device=False, visited={}, visited_min=0, remembered_target=0,
+    context,
+    remember_device=False,
+    visited={},
+    visited_min=0,
+    remembered_target=0,
 ):
-    remembered = False
-    # This should match the number of users that were created for the DB with the rake task
+    # This should match the number of users that were created for the DB with
+    # the rake task
     num_users = get_env("NUM_USERS")
+    remembered = False
 
     # Crossed minimum visited user threshold AND passed random selector
     if remember_device and use_previous_visitor(
@@ -68,7 +73,8 @@ def do_sign_in(
             print(f"You're already logged in. Quitting sign-in for {usernum}")
         return resp
 
-    remembered and print(f"Unexpected SMS prompt for remembered user {usernum}")
+    remembered and print(
+        f"Unexpected SMS prompt for remembered user {usernum}")
 
     auth_token = authenticity_token(resp)
     code = otp_code(resp)
@@ -87,7 +93,8 @@ def do_sign_in(
     )
 
     # Mark user as visited and save remembered device cookies
-    visited[usernum] = export_cookies(urlparse(resp.url).netloc, context.client.cookies)
+    visited[usernum] = export_cookies(
+        urlparse(resp.url).netloc, context.client.cookies)
 
     return resp
 

--- a/load_testing/common_flows/flow_sp_ial2_sign_in.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_in.py
@@ -1,0 +1,278 @@
+from faker import Faker
+from .flow_helper import (
+    authenticity_token,
+    do_request,
+    get_env,
+    otp_code,
+    personal_key,
+    querystring_value,
+    random_cred,
+    random_phone,
+    sp_signout_link,
+    url_without_querystring,
+)
+from urllib.parse import urlparse
+import os
+import sys
+
+"""
+*** SP IAL2 Sign In Flow ***
+"""
+
+
+def ial2_sign_in(context):
+    """
+    Requires following attributes on context:
+    * license_front - Image data for front of driver's license
+    * license_back - Image data for back of driver's license
+    """
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=2'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+
+    # TODO add debugging around this statement to further investigate
+    # https://github.com/18F/identity-loadtest/issues/25
+    request_id = querystring_value(resp.url, "request_id")
+
+    # This should match the number of users that were created for the DB with
+    # the rake task
+    num_users = get_env("NUM_USERS")
+    # Choose a random user
+    credentials = random_cred(num_users)
+
+    # POST username and password
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/login/two_factor/sms",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+    idp_domain = urlparse(resp.url).netloc
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /login/two_factor/sms")
+
+    # Post to unauthenticated redirect
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        "/verify/doc_auth/welcome",
+        {
+            "code": code,
+            "authenticity_token": auth_token,
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/welcome")
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/welcome",
+        "/verify/doc_auth/agreement",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/agreement")
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/agreement",
+        "/verify/doc_auth/upload",
+        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/upload?type=desktop")
+    # Choose Desktop flow
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/upload?type=desktop",
+        "/verify/doc_auth/document_capture",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    files = {"doc_auth[front_image]": context.license_front,
+             "doc_auth[back_image]": context.license_back}
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/document_capture")
+    # Post the license images
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/document_capture",
+        "/verify/doc_auth/ssn",
+        {"authenticity_token": auth_token, },
+        files
+    )
+    auth_token = authenticity_token(resp)
+
+    # SSN - use faker to get unique SSNs
+    fake = Faker()
+    ssn = fake.ssn()
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/ssn")
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/ssn",
+        "/verify/doc_auth/verify",
+        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn, },
+    )
+    # There are three auth tokens on the response, get the second
+    auth_token = authenticity_token(resp, 1)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/verify")
+    # Verify
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/verify",
+        "/verify/phone",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/phone")
+    # Enter Phone
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone",
+        "/verify/otp_delivery_method",
+        {"authenticity_token": auth_token,
+            "idv_phone_form[phone]": random_phone(), },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/otp_delivery_method")
+    # Select SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/otp_delivery_method",
+        "/verify/phone_confirmation",
+        {"authenticity_token": auth_token, "otp_delivery_preference": "sms", },
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/phone_confirmation")
+    # Verify SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone_confirmation",
+        "/verify/review",
+        {"authenticity_token": auth_token, "code": code, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/review")
+    # Re-enter password
+    resp = do_request(
+        context,
+        "put",
+        "/verify/review",
+        "/verify/confirmations",
+        {"authenticity_token": auth_token,
+            "user[password]": "salty pickles", },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/confirmations")
+    # Confirmations
+    resp = do_request(
+        context,
+        "post",
+        "/verify/confirmations",
+        "/sign_up/completed",
+        {
+            "authenticity_token": auth_token,
+            "personal_key": personal_key(resp)
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /sign_up/completed")
+    # Sign Up Completed
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/completed",
+        None,
+        {"authenticity_token": auth_token,
+         "commit": "Agree and continue"},
+    )
+
+    ial2_sig = "ACR: http://idmanagement.gov/ns/assurance/ial/2"
+    # Does it include the IAL2 text signature?
+    if resp.text.find(ial2_sig) == -1:
+        print("ERROR: this does not appear to be an IAL2 auth")
+
+    logout_link = sp_signout_link(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /sign_up/completed")
+    resp = do_request(
+        context,
+        "get",
+        logout_link,
+        sp_root_url,
+        {},
+        {},
+        url_without_querystring(logout_link),
+    )
+    # Does it include the logged out text signature?
+    if resp.text.find('You have been logged out') == -1:
+        print("ERROR: user has not been logged out")

--- a/load_testing/common_flows/flow_sp_ial2_sign_up.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_up.py
@@ -1,0 +1,321 @@
+from faker import Faker
+from .flow_helper import (
+    authenticity_token,
+    confirm_link,
+    do_request,
+    get_env,
+    otp_code,
+    personal_key,
+    querystring_value,
+    random_cred,
+    random_phone,
+    resp_to_dom,
+    sp_signout_link,
+    url_without_querystring,
+)
+from urllib.parse import urlparse
+import os
+import sys
+
+"""
+*** SP IAL2 Sign Up Flow ***
+"""
+
+
+def ial2_sign_up(context):
+    """
+    Requires following attributes on context:
+    * license_front - Image data for front of driver's license
+    * license_back - Image data for back of driver's license
+    """
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=2'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
+
+    # GET the new email page
+    resp = do_request(context, "get", "/sign_up/enter_email",
+                      "/sign_up/enter_email")
+    auth_token = authenticity_token(resp)
+
+    # Post fake email and get confirmation link (link shows up in "load test mode")
+    fake = Faker()
+    new_email = "test+{}@test.com".format(fake.md5())
+    default_password = "salty pickles"
+
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/enter_email",
+        "/sign_up/verify_email",
+        {
+            "user[email]": new_email,
+            "authenticity_token": auth_token,
+            "user[terms_accepted]": 'true'},
+    )
+
+    conf_url = confirm_link(resp)
+
+    # Get confirmation token
+    resp = do_request(
+        context,
+        "get",
+        conf_url,
+        "/sign_up/enter_password?confirmation_token=",
+        {},
+        {},
+        "/sign_up/email/confirm?confirmation_token=",
+    )
+    auth_token = authenticity_token(resp)
+    dom = resp_to_dom(resp)
+    token = dom.find('[name="confirmation_token"]:first').attr("value")
+
+    # Set user password
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/create_password",
+        "/two_factor_options",
+        {
+            "password_form[password]": default_password,
+            "authenticity_token": auth_token,
+            "confirmation_token": token,
+        },
+    )
+
+    # After password creation set up SMS 2nd factor
+    resp = do_request(context, "get", "/phone_setup", "/phone_setup")
+    auth_token = authenticity_token(resp)
+
+    resp = do_request(
+        context,
+        "post",
+        "/phone_setup",
+        "/login/two_factor/sms",
+        {
+            "_method": "patch",
+            "new_phone_form[international_code]": "US",
+            "new_phone_form[phone]": random_phone(),
+            "new_phone_form[otp_delivery_preference]": "sms",
+            "authenticity_token": auth_token,
+            "commit": "Send security code",
+        },
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /login/two_factor/sms")
+
+    # Visit security code page and submit pre-filled OTP
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        "/verify/doc_auth/welcome",
+        {"code": code, "authenticity_token": auth_token},
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/welcome")
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/welcome",
+        "/verify/doc_auth/agreement",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/agreement")
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/agreement",
+        "/verify/doc_auth/upload",
+        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/upload?type=desktop")
+    # Choose Desktop flow
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/upload?type=desktop",
+        "/verify/doc_auth/document_capture",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    files = {"doc_auth[front_image]": context.license_front,
+             "doc_auth[back_image]": context.license_back}
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/document_capture")
+    # Post the license images
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/document_capture",
+        "/verify/doc_auth/ssn",
+        {"authenticity_token": auth_token, },
+        files
+    )
+    auth_token = authenticity_token(resp)
+
+    # SSN - use faker to get unique SSNs
+    fake = Faker()
+    ssn = fake.ssn()
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/ssn")
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/ssn",
+        "/verify/doc_auth/verify",
+        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn, },
+    )
+    # There are three auth tokens on the response, get the second
+    auth_token = authenticity_token(resp, 1)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/doc_auth/verify")
+    # Verify
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/verify",
+        "/verify/phone",
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/phone")
+    # Enter Phone
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone",
+        "/verify/otp_delivery_method",
+        {"authenticity_token": auth_token,
+            "idv_phone_form[phone]": random_phone(), },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/otp_delivery_method")
+    # Select SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/otp_delivery_method",
+        "/verify/phone_confirmation",
+        {"authenticity_token": auth_token, "otp_delivery_preference": "sms", },
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/phone_confirmation")
+    # Verify SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone_confirmation",
+        "/verify/review",
+        {"authenticity_token": auth_token, "code": code, },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/review")
+    # Re-enter password
+    resp = do_request(
+        context,
+        "put",
+        "/verify/review",
+        "/verify/confirmations",
+        {"authenticity_token": auth_token,
+            "user[password]": "salty pickles", },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /verify/confirmations")
+    # Confirmations
+    resp = do_request(
+        context,
+        "post",
+        "/verify/confirmations",
+        "/sign_up/completed",
+        {
+            "authenticity_token": auth_token,
+            "personal_key": personal_key(resp)
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /sign_up/completed")
+    # Sign Up Completed
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/completed",
+        None,
+        {"authenticity_token": auth_token,
+         "commit": "Agree and continue"},
+    )
+
+    ial2_sig = "ACR: http://idmanagement.gov/ns/assurance/ial/2"
+    # Does it include the IAL2 text signature?
+    if resp.text.find(ial2_sig) == -1:
+        print("ERROR: this does not appear to be an IAL2 auth")
+
+    logout_link = sp_signout_link(resp)
+
+    if os.getenv("DEBUG"):
+        print("DEBUG: /sign_up/completed")
+    resp = do_request(
+        context,
+        "get",
+        logout_link,
+        sp_root_url,
+        {},
+        {},
+        url_without_querystring(logout_link),
+    )
+    # Does it include the logged out text signature?
+    if resp.text.find('You have been logged out') == -1:
+        print("ERROR: user has not been logged out")

--- a/load_testing/common_flows/flow_sp_sign_in.py
+++ b/load_testing/common_flows/flow_sp_sign_in.py
@@ -1,14 +1,21 @@
+from urllib.parse import urlparse
 from .flow_helper import (
     authenticity_token,
+    choose_cred,
     do_request,
+    export_cookies,
     get_env,
+    import_cookies,
     otp_code,
     querystring_value,
     random_cred,
+    resp_to_dom,
     sp_signin_link,
     sp_signout_link,
     url_without_querystring,
+    use_previous_visitor,
 )
+
 """
 *** Service Provider Sign In Flow ***
 
@@ -17,10 +24,19 @@ also requires that users are pre-generated in the IdP database.
 """
 
 
-def do_sp_sign_in(context):
+def do_sign_in(
+    context,
+    remember_device=False,
+    visited={},
+    visited_min=0,
+    remembered_target=0,
+):
     sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+    # print(f"cookie count for user: {len(context.client.cookies)}")
 
-    # GET the SP root, which should contain a login link, give it a friendly name for output
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
     resp = do_request(
         context,
         "get",
@@ -32,7 +48,6 @@ def do_sp_sign_in(context):
     )
 
     sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=1'
-
     # submit signin form
     resp = do_request(
         context,
@@ -43,18 +58,38 @@ def do_sp_sign_in(context):
         {},
         sp_signin_endpoint
     )
-
     auth_token = authenticity_token(resp)
     request_id = querystring_value(resp.url, "request_id")
 
-    # POST username and password
+    # This should match the number of users that were created for the DB with
+    # the rake task
     num_users = get_env("NUM_USERS")
-    credentials = random_cred(num_users)
+    remembered = False
+
+    # Crossed minimum visited user threshold AND passed random selector
+    if remember_device and use_previous_visitor(
+        len(visited), visited_min, remembered_target
+    ):
+        # Choose a specific previous user
+        credentials = choose_cred(visited.keys())
+
+        # Restore remembered device cookies to client jar
+        import_cookies(context.client, visited[credentials["number"]])
+        remembered = True
+    else:
+        # Choose a random user
+        credentials = random_cred(num_users)
+
+    usernum = credentials["number"]
+    auth_token = authenticity_token(resp)
+    expected_path = "/login/two_factor/sms" if remember_device is False else None
+
+    # POST username and password
     resp = do_request(
         context,
         "post",
         "/",
-        "/login/two_factor/sms",
+        expected_path,
         {
             "user[email]": credentials["email"],
             "user[password]": credentials["password"],
@@ -62,17 +97,25 @@ def do_sp_sign_in(context):
             "authenticity_token": auth_token,
         }
     )
+
+    if remembered and "/login/two_factor/sms" in resp.url:
+        print(f"Unexpected SMS prompt for remembered user {usernum}")
+
     auth_token = authenticity_token(resp)
     code = otp_code(resp)
+    idp_domain = urlparse(resp.url).netloc
 
-    # POST to 2FA
-    # If first time for user, this redirects to "completed", otherwise to the SP root.
+    # Post to unauthenticated redirect
     resp = do_request(
         context,
         "post",
         "/login/two_factor/sms",
         None,
-        {"code": code, "authenticity_token": auth_token, },
+        {
+            "code": code,
+            "authenticity_token": auth_token,
+            "remember_device": remember_device_value(remember_device),
+        },
     )
 
     if "/sign_up/completed" in resp.url:
@@ -86,10 +129,12 @@ def do_sp_sign_in(context):
             {"authenticity_token": auth_token, },
         )
 
+    sp_domain = urlparse(resp.url).netloc
+
     # We should now be at the SP root, with a "logout" link.
     # The test SP goes back to the root, so we'll test that for now
     logout_link = sp_signout_link(resp)
-    do_request(
+    resp = do_request(
         context,
         "get",
         logout_link,
@@ -98,3 +143,243 @@ def do_sp_sign_in(context):
         {},
         url_without_querystring(logout_link),
     )
+    # Does it include the you have been logged out text?
+    if resp.text.find('You have been logged out') == -1:
+        print("ERROR: user has not been logged out")
+
+    # Mark user as visited and save remembered device cookies
+    visited[usernum] = export_cookies(
+        idp_domain, context.client.cookies, None, sp_domain)
+
+
+def remember_device_value(value):
+    if value:
+        return "true"
+    else:
+        return "false"
+
+
+def do_sign_in_user_not_found(context):
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=1'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
+
+    # This should match the number of users that were created for the DB with
+    # the rake task
+    num_users = get_env("NUM_USERS")
+    credentials = random_cred(num_users)
+
+    # POST username and password
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+    resp = do_request(context, "get", "/", "/")
+    auth_token = authenticity_token(resp)
+
+    # Post login credentials
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/",
+        {
+            "user[email]":  "actually-not-" + credentials["email"],
+            "user[password]": credentials["password"],
+            "authenticity_token": auth_token,
+        },
+    )
+
+    # Validate that we got the expected response and were not redirect back for
+    # some other reason.
+    if resp.text.find('The email or password you’ve entered is wrong') == -1:
+        print("ERROR: the expected response for incorrect l/p is not present")
+
+    return resp
+
+
+def do_sign_in_incorrect_password(context):
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=1'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
+
+    # This should match the number of users that were created for the DB with
+    # the rake task
+    num_users = get_env("NUM_USERS")
+    credentials = random_cred(num_users)
+
+    # POST username and password
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+    resp = do_request(context, "get", "/", "/")
+    auth_token = authenticity_token(resp)
+
+    # Post login credentials
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": "bland pickles",
+            "authenticity_token": auth_token,
+        },
+    )
+
+    # Validate that we got the expected response and were not redirect back for
+    # some other reason.
+    if resp.text.find('The email or password you’ve entered is wrong') == -1:
+        print("ERROR: the expected response for incorrect l/p is not present")
+
+    return resp
+
+
+def do_sign_in_incorrect_sms_otp(context):
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=1'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
+
+    # This should match the number of users that were created for the DB with
+    # the rake task
+    num_users = get_env("NUM_USERS")
+    credentials = random_cred(num_users)
+
+    # POST username and password
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+    resp = do_request(context, "get", "/", "/")
+    auth_token = authenticity_token(resp)
+
+    # Post login credentials
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/login/two_factor/sms",
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "authenticity_token": auth_token,
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    # Post to unauthenticated redirect
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        "/login/two_factor/sms",
+        {"code": "000000", "authenticity_token": auth_token},
+    )
+
+    # Validate that we got the expected response and were not redirect back for
+    # some other reason.
+    if resp.text.find('That security code is invalid.') == -1:
+        print("ERROR: the expected response for incorrect OTP is not present")
+
+    return resp

--- a/load_testing/prod_simulator.locustfile.py
+++ b/load_testing/prod_simulator.locustfile.py
@@ -1,6 +1,14 @@
 import os
 from locust import HttpUser, TaskSet, task, between
-from common_flows import flow_ial2_proofing, flow_sign_in, flow_sign_up, flow_helper
+from common_flows import (
+    flow_ial2_proofing,
+    flow_sp_ial2_sign_in,
+    flow_sp_ial2_sign_up,
+    flow_sign_in,
+    flow_sp_sign_in,
+    flow_sp_sign_up,
+    flow_helper,
+)
 
 # Default ratios.  Sum should equal 10000.  (1 == 0.01%)
 # These can be overridden by setting the corresponding environment
@@ -48,7 +56,7 @@ class ProdSimulator(TaskSet):
         # TODO - Make these tunable
         # Wait till this percentage of users have visited before enabling
         # random visited user selection.
-        self.visited_min_pct = 1
+        self.visited_min_pct = 0.01
 
         # Target percentage of remembered users for regular sign_in
         self.remembered_target = REMEMBERED_PERCENT
@@ -66,52 +74,38 @@ class ProdSimulator(TaskSet):
     def sign_in_remembered_load_test(self):
         if os.getenv("DEBUG"):
             print("=== Starting Sign IN w/remembered device ===")
-        flow_sign_in.do_sign_in(
+        flow_sp_sign_in.do_sign_in(
             self,
             remember_device=True,
             visited=self.visited,
             visited_min=self.visited_min,
-            remembered_target=self.remembered_target,
-        )
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_helper.do_request(self, "get", "/logout", "/")
+            remembered_target=self.remembered_target,)
 
     @task(RATIOS["SIGN_UP"])
     def sign_up_load_test(self):
         if os.getenv("DEBUG"):
             print("=== Starting Sign UP ===")
-        flow_helper.do_request(self, "get", "/", "/")
-        flow_sign_up.do_sign_up(self)
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_helper.do_request(self, "get", "/logout", "/logout")
+        flow_sp_sign_up.do_sign_up(self)
 
     @task(RATIOS["SIGN_IN_AND_PROOF"])
     def sign_in_and_proof_load_test(self):
-        flow_sign_in.do_sign_in(self)
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_ial2_proofing.do_ial2_proofing(self)
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_helper.do_request(self, "get", "/logout", "/")
+        flow_sp_ial2_sign_in.ial2_sign_in(self)
 
     @task(RATIOS["SIGN_UP_AND_PROOF"])
     def sign_up_and_proof_load_test(self):
-        flow_sign_up.do_sign_up(self)
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_ial2_proofing.do_ial2_proofing(self)
-        flow_helper.do_request(self, "get", "/account", "/account")
-        flow_helper.do_request(self, "get", "/logout", "/")
+        flow_sp_ial2_sign_up.ial2_sign_up(self)
 
     @task(RATIOS["SIGN_IN_USER_NOT_FOUND"])
     def sign_in_load_test_user_not_found(self):
-        flow_sign_in.do_sign_in_user_not_found(self)
+        flow_sp_sign_in.do_sign_in_user_not_found(self)
 
     @task(RATIOS["SIGN_IN_INCORRECT_PASSWORD"])
     def sign_in_load_test_incorrect_password(self):
-        flow_sign_in.do_sign_in_incorrect_password(self)
+        flow_sp_sign_in.do_sign_in_incorrect_password(self)
 
     @task(RATIOS["SIGN_IN_INCORRECT_SMS_OTP"])
     def sign_in_load_test_incorrect_sms_otp(self):
-        flow_sign_in.do_sign_in_incorrect_sms_otp(self)
+        flow_sp_sign_in.do_sign_in_incorrect_sms_otp(self)
 
 
 class WebsiteUser(HttpUser):

--- a/load_testing/sp_sign_in.locustfile.py
+++ b/load_testing/sp_sign_in.locustfile.py
@@ -6,7 +6,7 @@ class SPSignInLoad(TaskSet):
     @task(1)
     def sp_sign_in_load_test(self):
         # This flow does its own SP logout
-        flow_sp_sign_in.do_sp_sign_in(self)
+        flow_sp_sign_in.do_sign_in(self)
 
 
 class WebsiteUser(HttpUser):


### PR DESCRIPTION
Open issues:
- [x] sp based sign_in
- [x] sp based sign_up
- [x] `no querystring key: request_id in url: https://idp.pt.identitysandbox.gov/user_authorization_confirmation` errors when combining `sign_in` and `sign_up` tasks in the `prod_simulator` flow.. Oddly the error doesn't occur when you run either task independently. That error is a sign that users are logged in to the IdP before the sp auth request.
  - This was fixed by clearing the cookies in the sign up flow. I believe the user cookies from the end of the sign in flow were used for the sign up flow causing the error. 
- [x] sp based sign_in_and_prooft
- [x] sp based sign_up_and_proof
- [x] sp based sign_in_load_test_user_not_found
- [x] sp based sign_in_load_test_incorrect_password
- [x] sp based sign_in_load_test_incorrect_sms_otp
- [x] fix test regression with cookie helper
- [x] fix `user has not been logged out` error in sign up flow