### PR TITLE
Wrong function referenced in sp_sign_up flow

### DIFF
--- a/load_testing/sp_sign_up.locustfile.py
+++ b/load_testing/sp_sign_up.locustfile.py
@@ -6,7 +6,7 @@ class SPSignUpLoad(TaskSet):
     @task(1)
     def sp_sign_up_load_test(self):
         # This flow does its own SP logout
-        flow_sp_sign_up.do_sp_sign_up(self)
+        flow_sp_sign_up.do_sign_up(self)
 
 
 class WebsiteUser(HttpUser):


### PR DESCRIPTION
Fixes 
```
[2021-07-02 22:22:06,753] jumphost-i-022ff37d06ccb80e1.pt.identitysandbox.gov/ERROR/locust.user.task: module 'common_flows.flow_sp_sign_up' has no attribute 'do_sp_sign_up'
Traceback (most recent call last):
File "/usr/local/lib/python3.6/dist-packages/locust/user/task.py", line 290, in run
  lf.execute_next_task()
File "/usr/local/lib/python3.6/dist-packages/locust/user/task.py", line 315, in execute_next_task
  lf.execute_task(self._task_queue.pop(0))
File "/usr/local/lib/python3.6/dist-packages/locust/user/task.py", line 327, in execute_task
  sk(self)
  Fi "/etc/login.gov/repos/identity-loadtest/load_testing/sp_sign_up.locustfile.py", line 9, in sp_sign_up_load_test
flow_sp_sign_up.do_sp_sign_up(self)
AttributeError: module 'common_flows.flow_sp_sign_up' has no attribute 'do_sp_sign_up'
```

It does have the function  [`do_sign_up`](https://github.com/18F/identity-loadtest/blob/main/load_testing/common_flows/flow_sp_sign_up.py#L26)
