### PR TITLE
Only set expected path to SP url if remembered is set

### DIFF
--- a/load_testing/common_flows/flow_sp_sign_in.py
+++ b/load_testing/common_flows/flow_sp_sign_in.py
@@ -102,9 +102,8 @@ def do_sign_in(
 
     usernum = credentials["number"]
 
-    if remember_device is False:
-        expected_path = "/login/two_factor/sms"
-    else:
+    expected_path = "/login/two_factor/sms" if remember_device is False else None
+    if remembered:
         expected_path = sp_root_url
 
     # POST username and password


### PR DESCRIPTION
This fixes a regression from the last PR. It was failing in the sign in flow when `remember_device` was set but there were no logged in users available.

```
SP_HOST=https://sp-oidc-sinatra.pt.identitysandbox.gov NUM_USERS=10000 /usr/local/bin/locust --host https://idp.pt.identitysandbox.gov --locustfile load_testing/prod_simulator.locustfile.py --users 100 --spawn-rate 10 --run-time 2m --logfile /tmp/locust.log --headless


 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /                                                            258     0(0.00%)  |      69      55     142      66  |    2.15    0.00
 POST /                                                          1581    20(1.27%)  |     670     448     966     680  |   13.20    0.17
 POST /login/two_factor/sms                                       619     0(0.00%)  |     282      72     428     280  |    5.17    0.00
 GET /phone_setup                                                 122     0(0.00%)  |      83      65     127      79  |    1.02    0.00
 POST /phone_setup                                                121     0(0.00%)  |     269     228     366     260  |    1.01    0.00
 POST /sign_up/completed                                          122     0(0.00%)  |     290     242     493     280  |    1.02    0.00
 POST /sign_up/create_password                                    122     0(0.00%)  |     370     338     452     370  |    1.02    0.00
 GET /sign_up/email/confirm?confirmation_token=                   122     0(0.00%)  |     137     114     186     140  |    1.02    0.00
 GET /sign_up/enter_email                                         122     0(0.00%)  |      66      55     132      63  |    1.02    0.00
 POST /sign_up/enter_email                                        122     0(0.00%)  |     316     274     508     310  |    1.02    0.00
 POST /verify/confirmations                                         3     0(0.00%)  |     204     181     240     190  |    0.03    0.00
 PUT /verify/doc_auth/agreement                                     3     0(0.00%)  |     188     178     206     180  |    0.03    0.00
 PUT /verify/doc_auth/document_capture                              3     0(0.00%)  |    8494    8454    8517    8500  |    0.03    0.00
 PUT /verify/doc_auth/ssn                                           3     0(0.00%)  |     185     180     189     189  |    0.03    0.00
 PUT /verify/doc_auth/upload?type=desktop                           3     0(0.00%)  |     177     170     187     170  |    0.03    0.00
 PUT /verify/doc_auth/verify                                        3     0(0.00%)  |    3365    3281    3457    3400  |    0.03    0.00
 PUT /verify/doc_auth/welcome                                       3     0(0.00%)  |     176     167     183     180  |    0.03    0.00
 PUT /verify/otp_delivery_method                                    3     0(0.00%)  |     238     224     261     230  |    0.03    0.00
 PUT /verify/phone                                                  3     0(0.00%)  |    1507    1473    1538    1500  |    0.03    0.00
 PUT /verify/phone_confirmation                                     3     0(0.00%)  |     263     238     279     270  |    0.03    0.00
 PUT /verify/review                                                 3     0(0.00%)  |    1893    1856    1943    1900  |    0.03    0.00
 GET https://idp.pt.identitysandbox.gov/openid_connect/logout     603     0(0.00%)  |     101      78     194      97  |    5.03    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov              1454     0(0.00%)  |      19      10     137      14  |   12.14    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request?aal=&ial=1    1449     0(0.00%)  |     143     109     718     130  |   12.10    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request?aal=&ial=2       3     0(0.00%)  |     132     117     156     120  |    0.03    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                      6853    20(0.29%)  |     261      10    8517     140  |   57.21    0.17
```

before:
```
SP_HOST=https://sp-oidc-sinatra.pt.identitysandbox.gov NUM_USERS=10000 /usr/local/bin/locust --host https://idp.pt.identitysandbox.gov --locustfile load_testing/prod_simulator.locustfile.py --users 100 --spawn-rate 10 --run-time 2m --logfile /tmp/locust.log --headless
...
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /                                                            255     0(0.00%)  |      69      55     146      66  |    2.14    0.00
 POST /                                                          1591 1082(68.01%)  |     634     455    1703     650  |   13.37    9.09
 POST /login/two_factor/sms                                       133     0(0.00%)  |     241      69    1207     240  |    1.12    0.00
 GET /phone_setup                                                 122     0(0.00%)  |      82      65     148      78  |    1.03    0.00
 POST /phone_setup                                                122     0(0.00%)  |     274     223    1307     260  |    1.03    0.00
 POST /sign_up/completed                                          122     0(0.00%)  |     310     257     393     310  |    1.03    0.00
 POST /sign_up/create_password                                    123     0(0.00%)  |     372     338     479     370  |    1.03    0.00
 GET /sign_up/email/confirm?confirmation_token=                   123     0(0.00%)  |     139     110     246     130  |    1.03    0.00
 GET /sign_up/enter_email                                         123     0(0.00%)  |      67      54     144      63  |    1.03    0.00
 POST /sign_up/enter_email                                        123     0(0.00%)  |     335     274    1274     310  |    1.03    0.00
 GET https://idp.pt.identitysandbox.gov/openid_connect/logout     122     0(0.00%)  |      99      81     153      95  |    1.03    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov              1468     0(0.00%)  |      19      10     149      15  |   12.34    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request?aal=&ial=1    1468     0(0.00%)  |     147     112    1156     130  |   12.34    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                      5895 1082(18.35%)  |     256      10    1703     130  |   49.55    9.09
```