### PR TITLE
Add SP IAL2 flows for async workers

### DIFF
--- a/load_testing/common_flows/flow_sp_ial2_sign_in_async.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_in_async.py
@@ -1,0 +1,293 @@
+from faker import Faker
+from .flow_helper import (
+    authenticity_token,
+    do_request,
+    get_env,
+    idv_phone_form_value,
+    otp_code,
+    personal_key,
+    querystring_value,
+    random_cred,
+    sp_signout_link,
+    url_without_querystring,
+)
+from urllib.parse import urlparse
+import logging
+import time
+
+"""
+*** SP IAL2 Sign In Flow ***
+"""
+
+
+def ial2_sign_in_async(context):
+    """
+    Requires following attributes on context:
+    * license_front - Image data for front of driver's license
+    * license_back - Image data for back of driver's license
+    """
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        '',
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=2'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+
+    # TODO add debugging around this statement to further investigate
+    # https://github.com/18F/identity-loadtest/issues/25
+    request_id = querystring_value(resp.url, "request_id")
+
+    # This should match the number of users that were created for the DB with
+    # the rake task
+    num_users = get_env("NUM_USERS")
+    # Choose a random user
+    credentials = random_cred(num_users, None)
+
+    # POST username and password
+    resp = do_request(
+        context,
+        "post",
+        "/",
+        "/login/two_factor/sms",
+        '',
+        {
+            "user[email]": credentials["email"],
+            "user[password]": credentials["password"],
+            "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+        }
+    )
+
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+    idp_domain = urlparse(resp.url).netloc
+
+    logging.debug('/login/two_factor/sms')
+    # Post to unauthenticated redirect
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        "/verify/doc_auth/welcome",
+        '',
+        {
+            "code": code,
+            "authenticity_token": auth_token,
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/welcome')
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/welcome",
+        "/verify/doc_auth/agreement",
+        '',
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/agreement')
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/agreement",
+        "/verify/doc_auth/upload",
+        '',
+        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/upload?type=desktop')
+    # Choose Desktop flow
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/upload?type=desktop",
+        "/verify/doc_auth/document_capture",
+        '',
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    files = {"doc_auth[front_image]": context.license_front,
+             "doc_auth[back_image]": context.license_back}
+
+    logging.debug('/verify/doc_auth/document_capture')
+    # Post the license images
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/document_capture",
+        "/verify/doc_auth/ssn",
+        '',
+        {"authenticity_token": auth_token, },
+        files
+    )
+    auth_token = authenticity_token(resp)
+
+    # SSN - use faker to get unique SSNs
+    fake = Faker()
+    ssn = fake.ssn()
+    logging.debug('/verify/doc_auth/ssn')
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/ssn",
+        "/verify/doc_auth/verify",
+        '',
+        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn, },
+    )
+    # There are three auth tokens in the response text, get the second
+    auth_token = authenticity_token(resp, 1)
+
+    logging.debug('/verify/doc_auth/verify')
+    # Verify
+    expected_text = 'This might take up to a minute. We’ll load the next step '\
+        'automatically when it’s done.'
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/verify",
+        '/verify/doc_auth/verify_wait',
+        expected_text,
+        {"authenticity_token": auth_token, },)
+
+    while resp.url == 'https://idp.pt.identitysandbox.gov/verify/doc_auth/verify_wait':
+        time.sleep(3)
+        logging.debug(
+            f"SLEEPING IN /verify_wait WHILE LOOP with #{credentials['email']}")
+        resp = do_request(
+            context,
+            "get",
+            "/verify/doc_auth/verify_wait",
+            '',
+            '',
+            {},
+        )
+        if resp.url == 'https://idp.pt.identitysandbox.gov/verify/doc_auth/verify_wait':
+            logging.debug(
+                f"STILL IN /verify_wait WHILE LOOP with #{credentials['email']}")
+        else:
+            auth_token = authenticity_token(resp)
+
+    logging.debug("/verify/phone")
+    # Enter Phone
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone",
+        '/verify/phone',
+        'This might take up to a minute',
+        {"authenticity_token": auth_token,
+            "idv_phone_form[phone]": idv_phone_form_value(resp), },
+    )
+
+    wait_text = 'This might take up to a minute. We’ll load the next step '\
+        'automatically when it’s done.'
+    while wait_text in resp.text:
+        time.sleep(3)
+        logging.debug(
+            f"SLEEPING IN /verify/phone WHILE LOOP with {credentials['email']}")
+        resp = do_request(
+            context,
+            "get",
+            "/verify/phone",
+            '',
+            '',
+            {},
+        )
+        if resp.url == 'https://idp.pt.identitysandbox.gov/verify/phone':
+            logging.debug(
+                f"STILL IN /verify/phone WHILE LOOP with {credentials['email']}")
+        else:
+            auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/review')
+    # Re-enter password
+    resp = do_request(
+        context,
+        "put",
+        "/verify/review",
+        "/verify/confirmations",
+        '',
+        {"authenticity_token": auth_token,
+            "user[password]": "salty pickles", },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/confirmations')
+    # Confirmations
+    resp = do_request(
+        context,
+        "post",
+        "/verify/confirmations",
+        "/sign_up/completed",
+        '',
+        {
+            "authenticity_token": auth_token,
+            "personal_key": personal_key(resp)
+        },
+    )
+
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/sign_up/completed')
+    # Sign Up Completed
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/completed",
+        None,
+        '',
+        {"authenticity_token": auth_token,
+         "commit": "Agree and continue"},
+    )
+
+    ial2_sig = "ACR: http://idmanagement.gov/ns/assurance/ial/2"
+    # Does it include the IAL2 text signature?
+    if resp.text.find(ial2_sig) == -1:
+        logging.error('this does not appear to be an IAL2 auth')
+
+    logout_link = sp_signout_link(resp)
+
+    logging.debug('SP /logout')
+    resp = do_request(
+        context,
+        "get",
+        logout_link,
+        sp_root_url,
+        '',
+        {},
+        {},
+        url_without_querystring(logout_link),
+    )
+    # Does it include the logged out text signature?
+    if resp.text.find('You have been logged out') == -1:
+        print("ERROR: user has not been logged out")

--- a/load_testing/common_flows/flow_sp_ial2_sign_up_async.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_up_async.py
@@ -1,0 +1,370 @@
+from faker import Faker
+from .flow_helper import (
+    authenticity_token,
+    confirm_link,
+    do_request,
+    get_env,
+    otp_code,
+    personal_key,
+    querystring_value,
+    random_phone,
+    resp_to_dom,
+    sp_signout_link,
+    url_without_querystring,
+)
+from urllib.parse import urlparse
+import logging
+import os
+import time
+
+"""
+*** SP IAL2 Sign Up Flow ***
+"""
+
+
+def ial2_sign_up_async(context):
+    """
+    Requires following attributes on context:
+    * license_front - Image data for front of driver's license
+    * license_back - Image data for back of driver's license
+    """
+    sp_root_url = get_env("SP_HOST")
+    context.client.cookies.clear()
+
+    # GET the SP root, which should contain a login link, give it a friendly
+    # name for output
+    resp = do_request(
+        context,
+        "get",
+        sp_root_url,
+        sp_root_url,
+        '',
+        {},
+        {},
+        sp_root_url
+    )
+
+    sp_signin_endpoint = sp_root_url + '/auth/request?aal=&ial=2'
+    # submit signin form
+    resp = do_request(
+        context,
+        "get",
+        sp_signin_endpoint,
+        '',
+        '',
+        {},
+        {},
+        sp_signin_endpoint
+    )
+    auth_token = authenticity_token(resp)
+    request_id = querystring_value(resp.url, "request_id")
+
+    # GET the new email page
+    resp = do_request(context, "get", "/sign_up/enter_email",
+                      "/sign_up/enter_email")
+    auth_token = authenticity_token(resp)
+
+    # Post fake email and get confirmation link (link shows up in "load test mode")
+    fake = Faker()
+    new_email = "test+{}@test.com".format(fake.md5())
+    default_password = "salty pickles"
+
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/enter_email",
+        "/sign_up/verify_email",
+        '',
+        {
+            "user[email]": new_email,
+            # this is in sign in, not needed here?
+            #  "user[request_id]": request_id,
+            "authenticity_token": auth_token,
+            "user[terms_accepted]": 'true'},
+    )
+
+    conf_url = confirm_link(resp)
+
+    # Get confirmation token
+    resp = do_request(
+        context,
+        "get",
+        conf_url,
+        "/sign_up/enter_password?confirmation_token=",
+        '',
+        {},
+        {},
+        "/sign_up/email/confirm?confirmation_token=",
+    )
+    auth_token = authenticity_token(resp)
+    dom = resp_to_dom(resp)
+    token = dom.find('[name="confirmation_token"]:first').attr("value")
+
+    # Set user password
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/create_password",
+        "/two_factor_options",
+        '',
+        {
+            "password_form[password]": default_password,
+            "authenticity_token": auth_token,
+            "confirmation_token": token,
+        },
+    )
+
+    # After password creation set up SMS 2nd factor
+    resp = do_request(context, "get", "/phone_setup", "/phone_setup")
+    auth_token = authenticity_token(resp)
+
+    resp = do_request(
+        context,
+        "post",
+        "/phone_setup",
+        "/login/two_factor/sms",
+        '',
+        {
+            "_method": "patch",
+            "new_phone_form[international_code]": "US",
+            "new_phone_form[phone]": random_phone(),
+            "new_phone_form[otp_delivery_preference]": "sms",
+            "authenticity_token": auth_token,
+            "commit": "Send security code",
+        },
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+
+    logging.debug('/login/two_factor/sms')
+    # Visit security code page and submit pre-filled OTP
+    resp = do_request(
+        context,
+        "post",
+        "/login/two_factor/sms",
+        "/verify/doc_auth/welcome",
+        '',
+        {"code": code, "authenticity_token": auth_token},
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/welcome')
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/welcome",
+        "/verify/doc_auth/agreement",
+        '',
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/agreement')
+    # Post consent to Welcome
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/agreement",
+        "/verify/doc_auth/upload",
+        '',
+        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/upload?type=desktop')
+    # Choose Desktop flow
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/upload?type=desktop",
+        "/verify/doc_auth/document_capture",
+        '',
+        {"authenticity_token": auth_token, },
+    )
+    auth_token = authenticity_token(resp)
+
+    files = {"doc_auth[front_image]": context.license_front,
+             "doc_auth[back_image]": context.license_back}
+
+    logging.debug('verify/doc_auth/document_capture')
+    # Post the license images
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/document_capture",
+        "/verify/doc_auth/ssn",
+        '',
+        {"authenticity_token": auth_token, },
+        files
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/doc_auth/ssn')
+    # SSN - use faker to get unique SSNs
+    fake = Faker()
+    ssn = fake.ssn()
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/ssn",
+        "/verify/doc_auth/verify",
+        '',
+        {"authenticity_token": auth_token, "doc_auth[ssn]": ssn, },
+    )
+    # There are three auth tokens on the response, get the second
+    auth_token = authenticity_token(resp, 1)
+
+    logging.debug('/verify/doc_auth/verify')
+    # Verify
+    expected_text = 'This might take up to a minute. We’ll load the next step '\
+        'automatically when it’s done.'
+    resp = do_request(
+        context,
+        "put",
+        "/verify/doc_auth/verify",
+        "/verify/doc_auth/verify_wait",
+        expected_text,
+        {"authenticity_token": auth_token, },
+    )
+
+    while resp.url == 'https://idp.pt.identitysandbox.gov/verify/doc_auth/verify_wait':
+        time.sleep(3)
+        logging.debug(
+            f"SLEEPING IN /verify_wait WHILE LOOP with {new_email}")
+        resp = do_request(
+            context,
+            "get",
+            "/verify/doc_auth/verify_wait",
+            '',
+            '',
+            {},
+        )
+        if resp.url == 'https://idp.pt.identitysandbox.gov/verify/doc_auth/verify_wait':
+            logging.debug(
+                f"STILL IN /verify_wait WHILE LOOP with {new_email}")
+        else:
+            auth_token = authenticity_token(resp)
+
+    logging.debug("/verify/phone")
+    # Enter Phone
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone",
+        "/verify/phone",
+        'This might take up to a minute',
+        {"authenticity_token": auth_token,
+            "idv_phone_form[phone]": random_phone(), },
+    )
+
+    wait_text = 'This might take up to a minute. We’ll load the next step '\
+        'automatically when it’s done.'
+    while wait_text in resp.text:
+        time.sleep(3)
+        logging.debug(
+            f"SLEEPING IN /verify/phone WHILE LOOP with {new_email}")
+        resp = do_request(
+            context,
+            "get",
+            "/verify/phone",
+            '',
+            '',
+            {},
+        )
+        if resp.url == 'https://idp.pt.identitysandbox.gov/verify/phone':
+            logging.debug(
+                f"STILL IN /verify/phone WHILE LOOP with {new_email}")
+        else:
+            auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/otp_delivery_method')
+    # Select SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/otp_delivery_method",
+        "/verify/phone_confirmation",
+        '',
+        {"authenticity_token": auth_token, "otp_delivery_preference": "sms", },
+    )
+    auth_token = authenticity_token(resp)
+    code = otp_code(resp)
+
+    logging.debug('/verify/phone_confirmation')
+    # Verify SMS Delivery
+    resp = do_request(
+        context,
+        "put",
+        "/verify/phone_confirmation",
+        "/verify/review",
+        '',
+        {"authenticity_token": auth_token, "code": code, },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/review')
+    # Re-enter password
+    resp = do_request(
+        context,
+        "put",
+        "/verify/review",
+        "/verify/confirmations",
+        '',
+        {
+            "authenticity_token": auth_token,
+            "user[password]": "salty pickles",
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/verify/confirmations')
+    # Confirmations
+    resp = do_request(
+        context,
+        "post",
+        "/verify/confirmations",
+        "/sign_up/completed",
+        '',
+        {
+            "authenticity_token": auth_token,
+            "personal_key": personal_key(resp)
+        },
+    )
+    auth_token = authenticity_token(resp)
+
+    logging.debug('/sign_up/completed')
+    # Sign Up Completed
+    resp = do_request(
+        context,
+        "post",
+        "/sign_up/completed",
+        None,
+        '',
+        {
+            "authenticity_token": auth_token,
+            "commit": "Agree and continue"
+        },
+    )
+
+    ial2_sig = "ACR: http://idmanagement.gov/ns/assurance/ial/2"
+    # Does it include the IAL2 text signature?
+    if resp.text.find(ial2_sig) == -1:
+        print("ERROR: this does not appear to be an IAL2 auth")
+
+    logout_link = sp_signout_link(resp)
+
+    logging.debug('/sign_up/completed')
+    resp = do_request(
+        context,
+        "get",
+        logout_link,
+        sp_root_url,
+        '',
+        {},
+        {},
+        url_without_querystring(logout_link),
+    )
+    # Does it include the logged out text signature?
+    if resp.text.find('You have been logged out') == -1:
+        print("ERROR: user has not been logged out")

--- a/load_testing/sp_ial2_sign_in_async.locustfile.py
+++ b/load_testing/sp_ial2_sign_in_async.locustfile.py
@@ -1,0 +1,21 @@
+from locust import HttpUser, TaskSet, task, between
+from common_flows import flow_sp_ial2_sign_in_async, flow_helper
+import logging
+
+
+class SP_IAL2_SignInLoad(TaskSet):
+    # Preload drivers license data
+    license_front = flow_helper.load_fixture("mont-front.jpeg")
+    license_back = flow_helper.load_fixture("mont-back.jpeg")
+    num = flow_helper.get_env("NUM_USERS")
+    logging.info(
+        f'starting sp_sign_in_load_test with {num} users of entropy")')
+
+    @task(1)
+    def sp_sign_in_load_test(self):
+        flow_sp_ial2_sign_in_async.ial2_sign_in_async(self)
+
+
+class WebsiteUser(HttpUser):
+    tasks = [SP_IAL2_SignInLoad]
+    wait_time = between(5, 9)

--- a/load_testing/sp_ial2_sign_up_async.locustfile.py
+++ b/load_testing/sp_ial2_sign_up_async.locustfile.py
@@ -1,0 +1,19 @@
+from locust import HttpUser, TaskSet, task, between
+from common_flows import flow_sp_ial2_sign_up_async, flow_helper
+import logging
+
+
+class SP_IAL2_SignUpLoad(TaskSet):
+    # Preload drivers license data
+    license_front = flow_helper.load_fixture("mont-front.jpeg")
+    license_back = flow_helper.load_fixture("mont-back.jpeg")
+    logging.info('starting sp_sign_up_load_test')
+
+    @task(1)
+    def sp_sign_up_load_test(self):
+        flow_sp_ial2_sign_up_async.ial2_sign_up_async(self)
+
+
+class WebsiteUser(HttpUser):
+    tasks = [SP_IAL2_SignUpLoad]
+    wait_time = between(5, 9)


### PR DESCRIPTION
There are subtle differences in the IAL2 flows when the async workers are enabled. This adds two new IAL2 flows so we can load test the async workers. It may look like a big change but most of it is CPd from https://github.com/18F/identity-loadtest/blob/main/load_testing/common_flows/flow_sp_ial2_sign_up.py and https://github.com/18F/identity-loadtest/blob/main/load_testing/common_flows/flow_sp_ial2_sign_in.py.  There's plenty of opportunity to DRY up the code, @vchugh has already started on that: https://github.com/18F/identity-loadtest/pull/45. 

You can run this locally or from the jumphost
```
export SP_HOST=https://sp-oidc-sinatra.pt.identitysandbox.gov
export NUM_USERS=2000000 
cd identity-loadtest
locust \
--host https://idp.pt.identitysandbox.gov \
--locustfile load_testing/sp_ial2_sign_in_async.locustfile.py \
--headless \
--logfile /tmp/locust.log \
--users 72 \
--spawn-rate 16 \
--run-time 15m
```

```
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 POST /                                                           795     0(0.00%)  |     612     506    1193     580  |    2.65    0.00
 POST /login/two_factor/sms                                       795     3(0.38%)  |     495     347    1207     480  |    2.65    0.01
 POST /sign_up/completed                                          727     0(0.00%)  |     451     365    1244     440  |    2.43    0.00
 POST /verify/confirmations                                       728     0(0.00%)  |     265     211    5569     250  |    2.43    0.00
 PUT /verify/doc_auth/agreement                                   792     0(0.00%)  |     193     158     323     190  |    2.64    0.00
 PUT /verify/doc_auth/document_capture                            788     0(0.00%)  |    8522    8407    9926    8500  |    2.63    0.00
 PUT /verify/doc_auth/ssn                                         787     0(0.00%)  |     279     204    2075     250  |    2.63    0.00
 PUT /verify/doc_auth/upload?type=desktop                         792     0(0.00%)  |     230     187    1831     220  |    2.64    0.00
 PUT /verify/doc_auth/verify                                      785     0(0.00%)  |     351     265    2130     330  |    2.62    0.00
 GET /verify/doc_auth/verify_wait                                 767     0(0.00%)  |     487     121    2316     440  |    2.56    0.00
 PUT /verify/doc_auth/welcome                                     792     0(0.00%)  |     202     159     680     200  |    2.64    0.00
 GET /verify/phone                                                742     0(0.00%)  |     291     239     428     290  |    2.48    0.00
 PUT /verify/phone                                                763     2(0.26%)  |     326     258    2128     310  |    2.55    0.01
 PUT /verify/review                                               730     0(0.00%)  |    1966    1816    2443    2000  |    2.44    0.00
 GET https://idp.pt.identitysandbox.gov/openid_connect/logout     727     0(0.00%)  |     133     103     305     130  |    2.43    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov               795     0(0.00%)  |      22      10     185      15  |    2.65    0.00
 GET https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request?aal=&ial=2     795     0(0.00%)  |     155     117     420     140  |    2.65    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                     13100     5(0.04%)  |     887      10    9926     290  |   43.70    0.02

Response time percentiles (approximated)
 Type     Name                                                              50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
 POST     /                                                                 580    610    640    670    720    790    880    940   1200   1200   1200    795
 POST     /login/two_factor/sms                                             480    500    520    530    570    600    660    690   1200   1200   1200    795
 POST     /sign_up/completed                                                440    460    470    480    510    530    570    590   1200   1200   1200    727
 POST     /verify/confirmations                                             250    260    270    280    290    310    330    350   5600   5600   5600    728
 PUT      /verify/doc_auth/agreement                                        190    200    200    210    220    240    250    270    320    320    320    792
 PUT      /verify/doc_auth/document_capture                                8500   8500   8500   8600   8600   8600   8700   8800   9900   9900   9900    788
 PUT      /verify/doc_auth/ssn                                              250    270    280    290    320    360    410   1100   2100   2100   2100    787
 PUT      /verify/doc_auth/upload?type=desktop                              220    230    240    240    260    280    300    320   1800   1800   1800    792
 PUT      /verify/doc_auth/verify                                           330    340    360    370    400    440    530    620   2100   2100   2100    785
 GET      /verify/doc_auth/verify_wait                                      440    450    470    480    520    600   1600   2000   2300   2300   2300    767
 PUT      /verify/doc_auth/welcome                                          200    200    210    220    230    250    270    280    680    680    680    792
 GET      /verify/phone                                                     290    300    310    310    330    340    360    380    430    430    430    742
 PUT      /verify/phone                                                     310    320    330    340    370    390    430    590   2100   2100   2100    763
 PUT      /verify/review                                                   2000   2000   2000   2000   2100   2100   2200   2200   2400   2400   2400    730
 GET      https://idp.pt.identitysandbox.gov/openid_connect/logout          130    130    140    140    160    180    230    250    310    310    310    727
 GET      https://sp-oidc-sinatra.pt.identitysandbox.gov                     15     17     19     20     39     83    110    120    190    190    190    795
 GET      https://sp-oidc-sinatra.pt.identitysandbox.gov/auth/request?aal=&ial=2      140    150    160    160    210    260    290    320    420    420    420    795
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
 None     Aggregated                                                        290    410    470    520   1900   8500   8500   8600   8700   9600   9900  13100

Error report
 # occurrences      Error                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------
 3                  POST /login/two_factor/sms: CatchResponseError('You wanted /verify/doc_auth/welcome, but got https://sp-oidc-sinatra.pt.identitysandbox.gov/ for a url.')
 2                  PUT /verify/phone: CatchResponseError('"This might take up to a minute" is not in the response text. Found the following fail msg(s): Need more time?')
--------------------------------------------------------------------------------------------------------------------------------------------
```
