### PR TITLE
send 1 instead of true for checkboxes

### DIFF
--- a/load_testing/common_flows/flow_ial2_proofing.py
+++ b/load_testing/common_flows/flow_ial2_proofing.py
@@ -35,7 +35,7 @@ def do_ial2_proofing(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         "",
-        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+        {"ial2_consent_given": "1", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sign_up.py
+++ b/load_testing/common_flows/flow_sign_up.py
@@ -34,7 +34,7 @@ def do_sign_up(context):
         {
             "user[email]": new_email,
             "authenticity_token": auth_token,
-            "user[terms_accepted]": 'true'
+            "user[terms_accepted]": '1'
         },
     )
 

--- a/load_testing/common_flows/flow_sp_ial2_sign_in.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_in.py
@@ -124,7 +124,7 @@ def ial2_sign_in(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         '',
-        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+        {"ial2_consent_given": "1", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sp_ial2_sign_in_async.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_in_async.py
@@ -120,7 +120,7 @@ def ial2_sign_in_async(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         '',
-        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+        {"ial2_consent_given": "1", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sp_ial2_sign_up.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_up.py
@@ -78,7 +78,7 @@ def ial2_sign_up(context):
         {
             "user[email]": new_email,
             "authenticity_token": auth_token,
-            "user[terms_accepted]": 'true'},
+            "user[terms_accepted]": '1'},
     )
 
     conf_url = confirm_link(resp)
@@ -170,7 +170,7 @@ def ial2_sign_up(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         '',
-        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+        {"ial2_consent_given": "1", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sp_ial2_sign_up_async.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_up_async.py
@@ -80,7 +80,7 @@ def ial2_sign_up_async(context):
             # this is in sign in, not needed here?
             #  "user[request_id]": request_id,
             "authenticity_token": auth_token,
-            "user[terms_accepted]": 'true'},
+            "user[terms_accepted]": '1'},
     )
 
     conf_url = confirm_link(resp)
@@ -168,7 +168,7 @@ def ial2_sign_up_async(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         '',
-        {"ial2_consent_given": "true", "authenticity_token": auth_token, },
+        {"ial2_consent_given": "1", "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sp_sign_up.py
+++ b/load_testing/common_flows/flow_sp_sign_up.py
@@ -75,7 +75,7 @@ def do_sign_up(context):
         {
             "user[email]": new_email,
             "authenticity_token": auth_token,
-            "user[terms_accepted]": 'true'},
+            "user[terms_accepted]": '1'},
     )
 
     conf_url = confirm_link(resp)


### PR DESCRIPTION
The IDP expects to compare to a value of `"1"` instead of `"true"` now