### PR TITLE
Reverts version of coverage libary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coverage==6.3.2
+coverage==6.2
 Faker==13.11.1
 locust==2.9.0
 pyquery==1.4.3


### PR DESCRIPTION
Apparently version `6.3.2` is not available in the python env on our instances. 

```
  * execute[install_locust] action run[2022-05-24T18:25:40+00:00] INFO: Processing execute[install_locust] action run (identity-jumphost::default line 114)

    [execute] ERROR: Could not find a version that satisfies the requirement coverage==6.3.2 (from versions: 3.0b3, 3.0, 3.0.1, 3.1b1, 3.1, 3.2b1, 3.2b2, 3.2b3, 3.2b4, 3.2, 3.3, 3.3.1, 3.4b1, 3.4b2, 3.4, 3.5b1, 3.5, 3.5.1b1, 3.5.1, 3.5.2b1, 3.5.2, 3.5.3, 3.6b1, 3.6b2, 3.6b3, 3.6, 3.7, 3.7.1, 4.0a1, 4.0a2, 4.0a3, 4.0a4, 4.0a5, 4.0a6, 4.0b1, 4.0b2, 4.0b3, 4.0, 4.0.1, 4.0.2, 4.0.3, 4.1b1, 4.1b2, 4.1b3, 4.1, 4.2b1, 4.2, 4.3, 4.3.1, 4.3.2, 4.3.3, 4.3.4, 4.4b1, 4.4, 4.4.1, 4.4.2, 4.5, 4.5.1, 4.5.2, 4.5.3, 4.5.4, 5.0a1, 5.0a2, 5.0a3, 5.0a4, 5.0a5, 5.0a6, 5.0a7, 5.0a8, 5.0b1, 5.0b2, 5.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.1, 5.2, 5.2.1, 5.3, 5.3.1, 5.4, 5.5, 5.6b1, 6.0b1, 6.0, 6.0.1, 6.0.2, 6.1, 6.1.1, 6.1.2, 6.2)
              ERROR: No matching distribution found for coverage==6.3.2
```