### PR TITLE
Revert to locust 2.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage==6.2
 Faker==13.11.1
-locust==2.9.0
+locust==2.8.6
 pyquery==1.4.3
 pytest==6.2.5


### PR DESCRIPTION
Our loadtest nodes still run Python 3.6 which is not compatible with locust 2.9