### PR TITLE
Keep the sign_up flows in sync with the IdP

### DIFF
--- a/load_testing/common_flows/flow_sp_ial2_sign_up.py
+++ b/load_testing/common_flows/flow_sp_ial2_sign_up.py
@@ -103,7 +103,7 @@ def ial2_sign_up(context):
         context,
         "post",
         "/sign_up/create_password",
-        "/two_factor_options",
+        "/authentication_methods_setup",
         '',
         {
             "password_form[password]": default_password,
@@ -170,7 +170,8 @@ def ial2_sign_up(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         '',
-        {"doc_auth[ial2_consent_given]": "1", "authenticity_token": auth_token, },
+        {"doc_auth[ial2_consent_given]": "1",
+            "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 

--- a/load_testing/common_flows/flow_sp_sign_up.py
+++ b/load_testing/common_flows/flow_sp_sign_up.py
@@ -100,7 +100,7 @@ def do_sign_up(context):
         context,
         "post",
         "/sign_up/create_password",
-        "/two_factor_options",
+        "/authentication_methods_setup",
         '',
         {
             "password_form[password]": default_password,


### PR DESCRIPTION
This change keeps this loadtest code in sync with the IdP https://github.com/18F/identity-idp/commit/cdea08fd55ff2f8a1e92a60009dad5b57a491e63