### PR TITLE
Updates flow with new IdP logout confirmation step

### DIFF
--- a/load_testing/lib/flow_helper.py
+++ b/load_testing/lib/flow_helper.py
@@ -15,7 +15,14 @@ LOG_NAME = __file__.split('/')[-1].split('.')[0]
 
 
 def do_request(
-    context, method, path, expected_redirect=None, expected_text=None, data={}, files={}, name=None
+    context,
+    method,
+    path,
+    expected_redirect=None,
+    expected_text=None,
+    data={},
+    files={},
+    name=None
 ):
 
     with getattr(context.client, method)(

--- a/load_testing/lib/flow_sp_sign_in.py
+++ b/load_testing/lib/flow_sp_sign_in.py
@@ -164,11 +164,29 @@ def do_sign_in(
         context,
         "get",
         logout_link,
+        '',
+        'Do you want to sign out of',
+        {},
+        {},
+        '/openid_connect/logout?client_id=...'
+    )
+
+    auth_token = authenticity_token(resp)
+    state = querystring_value(resp.url, 'state')
+    # Confirm the logout request on the IdP
+    resp = do_request(
+        context,
+        "post",
+        "/openid_connect/logout",
         sp_root_url,
         'You have been logged out',
-        {},
-        {},
-        url_without_querystring(logout_link),
+        {
+            "authenticity_token": auth_token,
+            "_method": "delete",
+            "client_id": "urn:gov:gsa:openidconnect:sp:sinatra",
+            "post_logout_redirect_uri": "https://oidc-sinatra.loadtest.identitysandbox.gov/logout",
+            "state": state
+        }
     )
     # Does it include the you have been logged out text?
     if resp.text.find('You have been logged out') == -1:

--- a/load_testing/lib/flow_sp_sign_up.py
+++ b/load_testing/lib/flow_sp_sign_up.py
@@ -160,13 +160,31 @@ def do_sign_up(context):
         context,
         "get",
         logout_link,
-        sp_root_url,
         '',
+        'Do you want to sign out of',
         {},
         {},
-        url_without_querystring(logout_link),
+        '/openid_connect/logout?client_id=...'
     )
 
-    # Does it include the logged out text signature?
+    auth_token = authenticity_token(resp)
+    state = querystring_value(resp.url, 'state')
+    # Confirm the logout request on the IdP
+    resp = do_request(
+        context,
+        "post",
+        "/openid_connect/logout",
+        sp_root_url,
+        'You have been logged out',
+        {
+            "authenticity_token": auth_token,
+            "_method": "delete",
+            "client_id": "urn:gov:gsa:openidconnect:sp:sinatra",
+            "post_logout_redirect_uri": "https://oidc-sinatra.loadtest.identitysandbox.gov/logout",
+            "state": state
+        }
+    )
+    # Does it include the you have been logged out text?
     if resp.text.find('You have been logged out') == -1:
-        logging.error(f"{LOG_NAME}: user has not been logged out")
+        logging.error('The user has not been logged out')
+        logging.error(f'resp.url = {resp.url}')

--- a/load_testing/prod_simulator.locustfile.py
+++ b/load_testing/prod_simulator.locustfile.py
@@ -16,7 +16,8 @@ root = logging.getLogger()
 root.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(formatter)
 root.addHandler(handler)
 
@@ -29,8 +30,8 @@ root.addHandler(handler)
 RATIOS = {
     "SIGN_IN": 7263,
     "SIGN_UP": 813,
-    "SIGN_IN_AND_PROOF": 9,
-    "SIGN_UP_AND_PROOF": 9,
+    "SIGN_IN_AND_PROOF": 0,
+    "SIGN_UP_AND_PROOF": 0,
     "SIGN_IN_USER_NOT_FOUND": 885,
     "SIGN_IN_INCORRECT_PASSWORD": 885,
     "SIGN_IN_INCORRECT_SMS_OTP": 79,


### PR DESCRIPTION
This adds a step to confirm the logout on the IdP as described in https://github.com/18F/identity-loadtest/issues/63.

I'm currently running into an error where it fails on the POST due to an unexpected redirect: 

```
ulimit -n 10240                             
export NUM_USERS=2000000
export SP_HOST=https://oidc-sinatra.loadtest.identitysandbox.gov/
export DEBUG=true
locust \
--host https://idp.pt.identitysandbox.gov \
--locustfile load_testing/sp_sign_in.locustfile.py \
--headless \
--logfile /tmp/locust.log \
--spawn-rate 6 \
--run-time 1m \
--users 1
```

```
Error report
# occurrences      Error                                                                                               
------------------|---------------------------------------------------------------------------------------------------------------------------------------------
2                  POST /openid_connect/logout: CatchResponseError('\n        You wanted https://oidc-sinatra.loadtest.identitysandbox.gov/, but got https://oidc-sinatra.loadtest.identitysandbox.gov/ for a response.\n        Request:\n            Method: GET\n            Path: https://oidc-sinatra.loadtest.identitysandbox.gov/\n            Data: None\n        Response:\n            Body: None')
------------------|---------------------------------------------------------------------------------------------------------------------------------------------

```

Fixes https://github.com/18F/identity-loadtest/issues/63