### PR TITLE
Update identity verification flows

### DIFF
--- a/load_testing/lib/flow_helper.py
+++ b/load_testing/lib/flow_helper.py
@@ -22,12 +22,13 @@ def do_request(
     expected_text=None,
     data={},
     files={},
-    name=None
+    name=None,
+    headers={}
 ):
 
     with getattr(context.client, method)(
         path,
-        headers=desktop_agent_headers(),
+        headers=desktop_agent_headers() | headers,
         data=data,
         files=files,
         catch_response=True,

--- a/load_testing/lib/flow_sp_sign_in.py
+++ b/load_testing/lib/flow_sp_sign_in.py
@@ -184,7 +184,7 @@ def do_sign_in(
             "authenticity_token": auth_token,
             "_method": "delete",
             "client_id": "urn:gov:gsa:openidconnect:sp:sinatra",
-            "post_logout_redirect_uri": "https://oidc-sinatra.loadtest.identitysandbox.gov/logout",
+            "post_logout_redirect_uri": f"{sp_root_url}/logout",
             "state": state
         }
     )

--- a/load_testing/lib/flow_sp_sign_up.py
+++ b/load_testing/lib/flow_sp_sign_up.py
@@ -207,7 +207,7 @@ def do_sign_up(context):
             "authenticity_token": auth_token,
             "_method": "delete",
             "client_id": "urn:gov:gsa:openidconnect:sp:sinatra",
-            "post_logout_redirect_uri": "https://oidc-sinatra.loadtest.identitysandbox.gov/logout",
+            "post_logout_redirect_uri": f"{sp_root_url}/logout",
             "state": state
         }
     )


### PR DESCRIPTION
This updates the identity verification flows, but excludes the "async" and ial2_sign_up since we are focused on prod-like environments.

Matches the behavior of production