### PR TITLE
Update flow_helper.py to work on EC2 and EKS

### DIFF
--- a/load_testing/lib/flow_helper.py
+++ b/load_testing/lib/flow_helper.py
@@ -28,7 +28,7 @@ def do_request(
 
     with getattr(context.client, method)(
         path,
-        headers=desktop_agent_headers() | headers,
+        headers={**desktop_agent_headers(), **headers},
         data=data,
         files=files,
         catch_response=True,


### PR DESCRIPTION
This PR fixes EC2-backed `locust-*` instances which are failing with the following message:

`unsupported operand type(s) for |: 'dict' and 'dict',"`