### PR TITLE
It appears the fail text has changed

### DIFF
--- a/load_testing/lib/flow_sp_sign_in.py
+++ b/load_testing/lib/flow_sp_sign_in.py
@@ -418,7 +418,7 @@ def do_sign_in_incorrect_sms_otp(context, visited={}):
         "post",
         "/login/two_factor/sms",
         "/login/two_factor/sms",
-        'That security code is invalid',
+        'That one-time code is invalid',
         {"code": "000000", "authenticity_token": auth_token},
     )
 


### PR DESCRIPTION
re: https://gsa-tts.slack.com/archives/C010L0SE4E8/p1672875008004909

<img width="1112" alt="Screen Shot 2023-01-05 at 11 00 14 PM" src="https://user-images.githubusercontent.com/24955/210947800-aa04a564-3415-4078-b442-fdc25d1cae21.png">
