### PR TITLE
new version of locust chart dropped

### DIFF
--- a/locust.yaml
+++ b/locust.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     chart: locust
     repoURL: https://charts.deliveryhero.io
-    targetRevision: 0.30.0
+    targetRevision: 0.31.1
     helm:
       values: |
         loadtest:


### PR DESCRIPTION
It's running 2.13.1, which I think is newer than what we have out there now.