### PR TITLE
update doc auth urls

### DIFF
--- a/load_testing/lib/flow_ial2_proofing.py
+++ b/load_testing/lib/flow_ial2_proofing.py
@@ -35,7 +35,8 @@ def do_ial2_proofing(context):
         "/verify/doc_auth/agreement",
         "/verify/doc_auth/upload",
         "",
-        {"doc_auth[ial2_consent_given]": "1", "authenticity_token": auth_token, },
+        {"doc_auth[ial2_consent_given]": "1",
+            "authenticity_token": auth_token, },
     )
     auth_token = authenticity_token(resp)
 
@@ -44,7 +45,7 @@ def do_ial2_proofing(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "",
         {"authenticity_token": auth_token, },
     )
@@ -57,7 +58,7 @@ def do_ial2_proofing(context):
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "/verify/doc_auth/ssn",
         "",
         {"authenticity_token": auth_token, },

--- a/load_testing/lib/flow_sp_ial2_sign_in.py
+++ b/load_testing/lib/flow_sp_ial2_sign_in.py
@@ -133,7 +133,7 @@ def ial2_sign_in(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         '',
         {"authenticity_token": auth_token, },
     )
@@ -152,7 +152,7 @@ def ial2_sign_in(context):
              }
 
     if os.getenv("DEBUG"):
-        print("DEBUG: /verify/doc_auth/document_capture")
+        print("DEBUG: /verify/document_capture")
     # Post the license images
     resp = do_request(
         context,
@@ -171,7 +171,7 @@ def ial2_sign_in(context):
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "/verify/ssn",
         None,
         {

--- a/load_testing/lib/flow_sp_ial2_sign_in_async.py
+++ b/load_testing/lib/flow_sp_ial2_sign_in_async.py
@@ -126,7 +126,7 @@ def ial2_sign_in_async(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         '',
         {"authenticity_token": auth_token, },
     )
@@ -135,12 +135,12 @@ def ial2_sign_in_async(context):
     files = {"doc_auth[front_image]": context.license_front,
              "doc_auth[back_image]": context.license_back}
 
-    logging.debug('/verify/doc_auth/document_capture')
+    logging.debug('/verify/document_capture')
     # Post the license images
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "/verify/doc_auth/ssn",
         '',
         {"authenticity_token": auth_token, },

--- a/load_testing/lib/flow_sp_ial2_sign_up.py
+++ b/load_testing/lib/flow_sp_ial2_sign_up.py
@@ -58,7 +58,6 @@ def ial2_sign_up(context):
         sp_signin_endpoint
     )
     auth_token = authenticity_token(resp)
-    request_id = querystring_value(resp.url, "request_id")
 
     # GET the new email page
     resp = do_request(context, "get", "/sign_up/enter_email",
@@ -211,7 +210,7 @@ def ial2_sign_up(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         '',
         {"authenticity_token": auth_token, },
     )
@@ -231,7 +230,7 @@ def ial2_sign_up(context):
              }
 
     if os.getenv("DEBUG"):
-        print("DEBUG: /verify/doc_auth/document_capture")
+        print("DEBUG: /verify/document_capture")
     # Post the license images
     resp = do_request(
         context,
@@ -250,7 +249,7 @@ def ial2_sign_up(context):
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "/verify/ssn",
         None,
         {

--- a/load_testing/lib/flow_sp_ial2_sign_up_async.py
+++ b/load_testing/lib/flow_sp_ial2_sign_up_async.py
@@ -221,7 +221,7 @@ def ial2_sign_up_async(context):
         context,
         "put",
         "/verify/doc_auth/upload?type=desktop",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         '',
         {"authenticity_token": auth_token, },
     )
@@ -235,7 +235,7 @@ def ial2_sign_up_async(context):
     resp = do_request(
         context,
         "put",
-        "/verify/doc_auth/document_capture",
+        "/verify/document_capture",
         "/verify/doc_auth/ssn",
         '',
         {"authenticity_token": auth_token, },

--- a/load_testing/lib/flow_sp_sign_up.py
+++ b/load_testing/lib/flow_sp_sign_up.py
@@ -54,7 +54,6 @@ def do_sign_up(context):
     )
 
     auth_token = authenticity_token(resp)
-    request_id = querystring_value(resp.url, "request_id")
 
     # GET the new email page
     resp = do_request(context, "get", "/sign_up/enter_email",


### PR DESCRIPTION
Last change needed to get us back on track.

```
locust \                             
--host https://idp.pt.identitysandbox.gov \
--locustfile load_testing/prod_simulator.locustfile.py \
--headless \
--logfile /tmp/locust.log \
--spawn-rate 6 \
--users 32
```

```
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /                                                                                 52     0(0.00%) |    751     522    1322    700 |    3.20        0.00
POST     /auth_method_confirmation/skip                                                     8     0(0.00%) |    178     118     414    140 |    0.70        0.00
POST     /authentication_methods_setup                                                      8     0(0.00%) |    188     152     268    170 |    0.60        0.00
POST     /login/two_factor/sms                                                             60     0(0.00%) |    370     148     612    360 |    4.00        0.00
POST     /openid_connect/logout                                                            55     0(0.00%) |    101      73     206     94 |    3.90        0.00
GET      /openid_connect/logout?client_id=...                                              55     0(0.00%) |     83      51     223     77 |    3.90        0.00
POST     /phone_setup                                                                       8     0(0.00%) |    316     275     403    300 |    0.60        0.00
POST     /sign_up/completed                                                                 7     0(0.00%) |    321     262     413    320 |    0.70        0.00
POST     /sign_up/create_password                                                           8     0(0.00%) |    566     445     735    520 |    0.60        0.00
GET      /sign_up/email/confirm?confirmation_token=                                         8     0(0.00%) |    158     103     191    150 |    0.50        0.00
GET      /sign_up/enter_email                                                               9     0(0.00%) |     69      48     100     65 |    0.40        0.00
POST     /sign_up/enter_email                                                               8     0(0.00%) |    585     406     807    620 |    0.50        0.00
PUT      /verify/doc_auth/agreement                                                         5     0(0.00%) |    251     199     324    250 |    0.40        0.00
PUT      /verify/doc_auth/upload?type=desktop                                               5     0(0.00%) |    227     195     270    220 |    0.40        0.00
PUT      /verify/doc_auth/welcome                                                           5     0(0.00%) |    250     221     353    230 |    0.30        0.00
GET      https://oidc-sinatra.loadtest.identitysandbox.gov                                 63     0(0.00%) |     72      14     220     88 |    3.40        0.00
GET      https://oidc-sinatra.loadtest.identitysandbox.gov/auth/request?aal=&ial=1         57     0(0.00%) |    175      98     357    160 |    3.20        0.00
GET      https://oidc-sinatra.loadtest.identitysandbox.gov/auth/request?aal=&ial=2          5     0(0.00%) |    194     100     376    150 |    0.20        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                       426     0(0.00%) |    257      14    1322    160 |   27.50        0.00
```
