### PR TITLE
Updating cluster version to match what was updated via the console

### DIFF
--- a/terraform/loadtest_cluster.tf
+++ b/terraform/loadtest_cluster.tf
@@ -15,7 +15,7 @@ module "loadtest" {
   private_subnet_ids = module.vpc.private_subnets
 
   # EKS CLUSTER VERSION
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   cluster_name = var.cluster_name
 


### PR DESCRIPTION
I updated the EKS cluster via the AWS console. This updates the version in the TF code.