### PR TITLE
Update EKS locust bits

### DIFF
--- a/locust.yaml
+++ b/locust.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     chart: locust
     repoURL: https://charts.deliveryhero.io
-    targetRevision: 0.31.2
+    targetRevision: 0.31.6
     helm:
       values: |
         loadtest:

--- a/locust.yaml
+++ b/locust.yaml
@@ -59,12 +59,13 @@ spec:
           locust_lib_configmap: login-loadtest-lib
           locust_locustfile: sp_sign_up.locustfile.py
           pip_packages:
-            - coverage==6.2
-            - Faker==13.11.1
-            - pyquery==1.4.3
-            - pyzmq==24.0.1
+            - coverage==7.5.3
+            - Faker==25.4.0
+            - pyquery==2.0.0
+            - pytest==8.2.1
+            - pyzmq==26.0.3
         master:
-          image: 894947205914.dkr.ecr.us-west-2.amazonaws.com/locustio/locust:2.12.1
+          image: 894947205914.dkr.ecr.us-west-2.amazonaws.com/locustio/locust:2.28.0
           nodeSelector:
             eks.amazonaws.com/capacityType: "ON_DEMAND"
           args:


### PR DESCRIPTION
This updates the image in ECR with locust 2.28.0. I did so using the following commands:

```
brew install --cask docker
docker pull locustio/locust:2.28.0
aws-vault exec sandbox-admin -- aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin <aws_account>.dkr.ecr.us-west-2.amazonaws.com
docker tag locustio/locust:2.28.0 <aws_account>..dkr.ecr.us-west-2.amazonaws.com/locustio/locust:2.28.0
docker push <aws_account>..dkr.ecr.us-west-2.amazonaws.com/locustio/locust:2.28.0
```

This also updates the dependencies installed via pip.