### PR TITLE
fix(loadtest): record request helper failures

### DIFF
--- a/load_testing/lib/flow_helper.py
+++ b/load_testing/lib/flow_helper.py
@@ -31,6 +31,9 @@ def do_request(
         catch_response=True,
         name=name,
     ) as resp:
+        if resp.status_code >= 400:
+            fail_response_status(resp)
+            raise locust.exception.RescheduleTask
         if expected_redirect:
             if resp.url and expected_redirect not in resp.url:
                 fail_response(resp, expected_redirect, expected_text)
@@ -40,6 +43,14 @@ def do_request(
                 fail_response(resp, expected_redirect, expected_text)
                 raise locust.exception.RescheduleTask
         return resp
+
+
+def fail_response_status(response):
+    message = (
+        f"{response.request.method} {response.url} returned "
+        f"{response.status_code} {response.reason}"
+    )
+    response.failure(message)
 
 
 def fail_response(response, expected_redirect, expected_text):
@@ -153,14 +164,17 @@ def idv_phone_form_value(response):
     return value
 
 
-def querystring_value(url, key):
+def querystring_value(url, key, response=None):
     # Get a querystring value from a url
     parsed = urlparse(url)
     try:
         return parse_qs(parsed.query)[key][0]
     except KeyError as e:
-        logging.error(f"{LOG_NAME}: No querystring found for {key} in {url}")
+        error = f"No querystring value found for {key} in {url}"
+        logging.error(f"{LOG_NAME}: {error}")
         logging.debug(e)
+        if response:
+            response.failure(error)
         raise locust.exception.RescheduleTask
 
 

--- a/load_testing/lib/flow_sp_ial2_sign_in.py
+++ b/load_testing/lib/flow_sp_ial2_sign_in.py
@@ -376,7 +376,7 @@ def ial2_sign_in(context):
     )
 
     auth_token = authenticity_token(resp)
-    state = querystring_value(resp.url, "state")
+    state = querystring_value(resp.url, "state", resp)
     # Confirm the logout request on the IdP
     resp = do_request(
         context,

--- a/load_testing/lib/flow_sp_ial2_sign_up.py
+++ b/load_testing/lib/flow_sp_ial2_sign_up.py
@@ -433,7 +433,7 @@ def ial2_sign_up(context):
     )
 
     auth_token = authenticity_token(resp)
-    state = querystring_value(resp.url, "state")
+    state = querystring_value(resp.url, "state", resp)
     # Confirm the logout request on the IdP
     resp = do_request(
         context,

--- a/load_testing/lib/flow_sp_sign_in.py
+++ b/load_testing/lib/flow_sp_sign_in.py
@@ -155,7 +155,7 @@ def do_sign_in(
     )
 
     auth_token = authenticity_token(resp)
-    state = querystring_value(resp.url, "state")
+    state = querystring_value(resp.url, "state", resp)
     # Confirm the logout request on the IdP
     resp = do_request(
         context,

--- a/load_testing/lib/flow_sp_sign_up.py
+++ b/load_testing/lib/flow_sp_sign_up.py
@@ -179,7 +179,7 @@ def do_sign_up(context):
     )
 
     auth_token = authenticity_token(resp)
-    state = querystring_value(resp.url, "state")
+    state = querystring_value(resp.url, "state", resp)
     # Confirm the logout request on the IdP
     resp = do_request(
         context,

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -17,6 +17,7 @@ from lib.flow_helper import (
     choose_cred,
     confirm_link,
     desktop_agent_headers,
+    do_request,
     export_cookies,
     get_env,
     import_cookies,
@@ -41,6 +42,18 @@ def test_querystring_value():
     url = "http://one.two?three=four&five=six"
     assert querystring_value(url, "three") == "four"
     assert querystring_value(url, "five") == "six"
+
+
+def test_querystring_value_marks_response_failure_when_key_missing():
+    response = test_helper.mock_response("doc_auth_verify.html")
+    response.url = "http://one.two?three=four"
+
+    with pytest.raises(Exception):
+        querystring_value(response.url, "five", response)
+
+    response.failure.assert_called_once_with(
+        "No querystring value found for five in http://one.two?three=four"
+    )
 
 
 def test_url_without_querystring():
@@ -106,6 +119,18 @@ def test_get_env():
 def test_resp_to_dom():
     resp = test_helper.mock_response("doc_auth_verify.html")
     assert resp_to_dom(resp)
+
+
+def test_do_request_marks_http_errors_as_failures():
+    context = test_helper.mock_context()
+
+    with pytest.raises(Exception):
+        do_request(context, "get", "/example")
+
+    response = context.client.get.return_value.__enter__.return_value
+    response.failure.assert_called_once_with(
+        "GET http://example.test/example returned 500 Internal Server Error"
+    )
 
 
 def test_authentication_token():

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -18,3 +18,14 @@ def mock_response(fixture_name):
     response.content = fixture_content
 
     return response
+
+
+def mock_context():
+    context = MagicMock()
+    response = context.client.get.return_value.__enter__.return_value
+    response.status_code = 500
+    response.reason = "Internal Server Error"
+    response.url = "http://example.test/example"
+    response.request.method = "GET"
+
+    return context


### PR DESCRIPTION
## Summary

- Mark HTTP 4xx/5xx responses as Locust request failures in the shared request helper
- Let query-string extraction mark the originating response as failed when an expected key is missing
- Add regression tests for HTTP error accounting and missing query-string keys

Fixes #24.
Fixes #25.

## Tests

- `.venv/bin/python -m pytest`
